### PR TITLE
feat: add scheduled GitHub Actions workflow for weekly scanner runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
 
+# Turso (optional — used by the scheduled GitHub Actions scan)
+# Leave blank for local development (SQLite will be used instead)
+TURSO_DATABASE_URL=libsql://your-database-name.turso.io
+TURSO_AUTH_TOKEN=
+
 # Polymarket API base URLs (configurable for testing or API migration)
 POLYMARKET_DATA_API_BASE=https://data-api.polymarket.com
 POLYMARKET_GAMMA_API_BASE=https://gamma-api.polymarket.com

--- a/README.md
+++ b/README.md
@@ -252,6 +252,60 @@ Filtering this down to the top ~50 wallets with consistent, risk-adjusted skill 
 
 ---
 
+## Automated scans
+
+The repository includes a GitHub Actions workflow (`.github/workflows/scheduled-scan.yml`) that
+runs the wallet scanner automatically every **Monday at 06:00 UTC** and writes results to Turso,
+so the leaderboard stays fresh without needing to open Codespaces.
+
+### Changing the schedule
+
+Edit the `cron` line in `.github/workflows/scheduled-scan.yml`:
+
+```yaml
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # ← change this
+```
+
+Use [crontab.guru](https://crontab.guru) to build a cron expression. Examples:
+
+| Schedule | Expression |
+|---|---|
+| Every day at midnight UTC | `0 0 * * *` |
+| Every 6 hours | `0 */6 * * *` |
+| Weekdays at 07:00 UTC | `0 7 * * 1-5` |
+
+### Manual trigger
+
+Go to **Actions → Scheduled Wallet Scan → Run workflow** to kick off a scan immediately
+without waiting for the next cron tick.
+
+### Required GitHub secrets
+
+Add these under **Settings → Secrets and variables → Actions → New repository secret**:
+
+| Secret | What it is |
+|---|---|
+| `ANTHROPIC_API_KEY` | Your Anthropic API key (`sk-ant-...`) |
+| `TURSO_DATABASE_URL` | Your Turso database URL (`libsql://yourdb.turso.io`) |
+| `TURSO_AUTH_TOKEN` | Turso auth token for the database |
+
+To create a Turso database: `turso db create wallet-scanner` then `turso db show wallet-scanner`.
+
+### Cost expectations
+
+| Cost | Estimate |
+|---|---|
+| GitHub Actions runtime per scan | ~30 min (free tier: 2,000 min/month — ~66 scans) |
+| Anthropic API per scan | ~$2–4 (Claude called on top 200 wallets only) |
+
+Actions runtime is free; Claude API calls are not. The `--incremental` flag skips wallets
+refreshed in the last 24 hours and skips Claude reviews completed in the last 7 days,
+keeping per-run API costs low for weekly cadence.
+
+---
+
 ## Running tests
 
 ```bash

--- a/claude.md
+++ b/claude.md
@@ -151,6 +151,36 @@ When adding new functionality, prefer extending an existing module over creating
 - textual: https://textual.textualize.io/
 - FastAPI: https://fastapi.tiangolo.com/
 
+## Scheduled scans
+
+Weekly scans run automatically via `.github/workflows/scheduled-scan.yml` (every Monday at
+06:00 UTC, plus on-demand via `workflow_dispatch`). The workflow runs:
+
+```bash
+python main.py scan --incremental
+```
+
+with `ANTHROPIC_API_KEY`, `TURSO_DATABASE_URL`, and `TURSO_AUTH_TOKEN` injected as GitHub
+secrets. Results are written to a Turso database (libsql embedded replica) and pushed at the
+end of each scan.
+
+**Rules that must be preserved in any future scanner changes:**
+
+1. **`--incremental` flag must always be accepted by `python main.py scan`.**
+   - Skips wallets refreshed in the last 24 hours (controlled by `WALLET_CACHE_TTL`)
+   - Skips Claude qualitative review for wallets reviewed in the last 7 days
+   - Still re-ranks all wallets and writes the full leaderboard on every run
+   - On first run with an empty DB, falls back to full wallet discovery automatically
+
+2. **The Turso write path must stay intact.** When `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`
+   are set, the database layer uses a libsql embedded replica (`data/turso_replica.db`) that
+   syncs to Turso at the end of each scan via `sync_to_turso()` in `data/database.py`.
+   Do not remove or bypass this call in `scanner/scanner.py`.
+
+3. **Cost discipline on the scheduled path.** The `--incremental` flag is what keeps the
+   scheduled run from calling Claude on the full top-200 list every week. If you change the
+   Claude review logic, ensure freshness skipping still works.
+
 ## When in doubt
 
-Ask the owner. Scope discipline matters, but the owner decides what's in scope. When the owner makes a call that contradicts a previous instruction here, follow the owner — and update this file accordingly.board, hosted alerts) is a feature, not a violation.
+Ask the owner. Scope discipline matters, but the owner decides what's in scope. When the owner makes a call that contradicts a previous instruction here, follow the owner — and update this file accordingly.

--- a/config.py
+++ b/config.py
@@ -55,6 +55,11 @@ except OSError:
     pass  # read-only filesystem (e.g. Vercel) — DATABASE_URL env var must be set
 DATABASE_URL: str = os.getenv("DATABASE_URL", f"sqlite:///{DATA_DIR}/research.db")
 
+# ── Turso (optional — replaces local SQLite when running in CI/cloud) ─────────
+# Set both to use Turso instead of SQLite. Leave blank for local development.
+TURSO_DATABASE_URL: str = os.getenv("TURSO_DATABASE_URL", "")
+TURSO_AUTH_TOKEN: str = os.getenv("TURSO_AUTH_TOKEN", "")
+
 # ── Cache TTLs (seconds) ──────────────────────────────────────────────────────
 # Wallet is considered fresh for 24 h; re-scanned in incremental mode if older
 WALLET_CACHE_TTL: int = int(os.getenv("WALLET_CACHE_TTL", "86400"))

--- a/data/database.py
+++ b/data/database.py
@@ -4,19 +4,41 @@ from collections.abc import Generator
 
 from sqlmodel import Session, SQLModel, create_engine
 
-from config import DATABASE_URL
+from config import DATA_DIR, DATABASE_URL, TURSO_AUTH_TOKEN, TURSO_DATABASE_URL
 
-# Single shared engine — SQLite is single-writer, so one engine is correct
-_engine = create_engine(
-    DATABASE_URL,
-    connect_args={"check_same_thread": False},
-    echo=False,
-)
+_turso_connection = None
+
+if TURSO_DATABASE_URL and TURSO_AUTH_TOKEN:
+    try:
+        import libsql_experimental as libsql  # type: ignore[import]
+    except ImportError as exc:
+        raise RuntimeError(
+            "TURSO_DATABASE_URL is set but libsql-experimental is not installed. "
+            "Run: pip install libsql-experimental"
+        ) from exc
+
+    from sqlalchemy.pool import StaticPool
+
+    _local_replica = str(DATA_DIR / "turso_replica.db")
+    _turso_connection = libsql.connect(
+        _local_replica, sync_url=TURSO_DATABASE_URL, auth_token=TURSO_AUTH_TOKEN
+    )
+    _turso_connection.sync()  # Pull latest from Turso before operating
+    _engine = create_engine(
+        "sqlite+pysqlite://",
+        creator=lambda: _turso_connection,
+        poolclass=StaticPool,
+    )
+else:
+    _engine = create_engine(
+        DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        echo=False,
+    )
 
 
 def init_db() -> None:
     """Create all tables if they don't already exist. Safe to call repeatedly."""
-    # Import schema so SQLModel registers all table metadata before create_all
     import data.schema  # noqa: F401
 
     SQLModel.metadata.create_all(_engine)
@@ -29,3 +51,9 @@ def get_engine():
 def get_session() -> Generator[Session, None, None]:
     with Session(_engine) as session:
         yield session
+
+
+def sync_to_turso() -> None:
+    """Push local replica writes to Turso. No-op when using local SQLite."""
+    if _turso_connection is not None:
+        _turso_connection.sync()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ rich>=13.7.0
 textual>=0.70.0
 python-dotenv>=1.0.0
 click>=8.1.0
-libsql-experimental>=0.3.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 ruff>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ rich>=13.7.0
 textual>=0.70.0
 python-dotenv>=1.0.0
 click>=8.1.0
+libsql-experimental>=0.3.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 ruff>=0.4.0

--- a/scanner/repository.py
+++ b/scanner/repository.py
@@ -192,6 +192,13 @@ def get_ranking_for_wallet(address: str) -> WalletRanking | None:
         return s.get(WalletRanking, address)
 
 
+def get_rankings_for_wallets(addresses: list[str]) -> dict[str, WalletRanking]:
+    """Return a mapping of address → WalletRanking for the given addresses."""
+    with _session() as s:
+        stmt = select(WalletRanking).where(WalletRanking.wallet_address.in_(addresses))
+        return {r.wallet_address: r for r in s.exec(stmt).all()}
+
+
 # ── Watched wallets ───────────────────────────────────────────────────────────
 
 def add_to_watchlist(address: str) -> bool:

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from config import CLAUDE_REVIEW_TOP_N, setup_logging
-from data.database import init_db
+from data.database import init_db, sync_to_turso
 from data.schema import WalletMetrics, WalletRanking
 from scanner import repository as repo
 from scanner.client import PolymarketClient
@@ -14,8 +14,8 @@ from scanner.ranking import rank_wallets
 
 logger = logging.getLogger(__name__)
 
-# Limit concurrent wallet fetches to avoid flooding the API even with rate-limiting
 _CONCURRENCY = 50
+_CLAUDE_REVIEW_TTL_DAYS = 7
 
 
 async def run_scan(
@@ -24,13 +24,13 @@ async def run_scan(
 ) -> list[WalletRanking]:
     """
     Full scan pipeline:
-      1. Discover/load wallet addresses
+      1. Decide which wallets to refresh (all, or only stale ones in incremental mode)
       2. Fetch trade histories (async, bounded concurrency)
-      3. Compute metrics, apply hard filters
-      4. Rank wallets
+      3. Load all metrics from DB + apply hard filters
+      4. Rank ALL wallets (not just refreshed ones)
       5. Detect heuristic red flags
-      6. Claude qualitative review on top N
-      7. Persist results — all DB writes atomic
+      6. Claude qualitative review on top N (skip fresh reviews in incremental mode)
+      7. Sync writes to Turso (no-op if using local SQLite)
 
     Returns the final ranked list.
     """
@@ -38,58 +38,62 @@ async def run_scan(
     init_db()
 
     async with PolymarketClient() as client:
-        # ── Step 1: Wallet discovery ──────────────────────────────────────
+        # ── Step 1: Determine which wallets to fetch ──────────────────────────
         if incremental:
             stale = repo.get_stale_wallets(older_than_hours=24)
-            addresses = [w.address for w in stale]
-            logger.info("Incremental mode: %d wallets to refresh", len(addresses))
+            addresses_to_refresh = [w.address for w in stale]
+
+            if not addresses_to_refresh:
+                if not repo.get_all_wallets():
+                    # Empty DB — first scheduled run, fall back to full discovery
+                    logger.info("Incremental: empty DB, running initial wallet discovery")
+                    addresses_to_refresh = await client.get_all_traders(max_wallets=max_wallets)
+                    repo.upsert_wallets(addresses_to_refresh)
+                else:
+                    logger.info("Incremental: all wallets are fresh, skipping fetch phase")
+            else:
+                logger.info("Incremental: %d stale wallets to refresh", len(addresses_to_refresh))
         else:
-            addresses = await client.get_all_traders(max_wallets=max_wallets)
-            repo.upsert_wallets(addresses)
-            logger.info("Full scan: %d wallet addresses", len(addresses))
+            addresses_to_refresh = await client.get_all_traders(max_wallets=max_wallets)
+            repo.upsert_wallets(addresses_to_refresh)
+            logger.info("Full scan: %d wallet addresses", len(addresses_to_refresh))
 
-        if not addresses:
-            logger.warning("No wallets to process — exiting early")
-            return []
+        # ── Step 2: Fetch + compute metrics (bounded concurrency) ─────────────
+        if addresses_to_refresh:
+            sem = asyncio.Semaphore(_CONCURRENCY)
 
-        # ── Step 2: Fetch + compute metrics (bounded concurrency) ─────────
-        sem = asyncio.Semaphore(_CONCURRENCY)
-        all_metrics: list[WalletMetrics] = []
+            async def process_wallet(address: str) -> None:
+                async with sem:
+                    try:
+                        raw_trades = await client.get_wallet_trades(address)
+                        if not raw_trades:
+                            return
+                        trades = parse_trades(address, raw_trades)
+                        repo.upsert_trades(trades)
+                        metrics = compute_metrics(trades)
+                        if metrics:
+                            repo.upsert_metrics(metrics)
+                        repo.mark_wallet_scanned(address)
+                    except Exception as exc:
+                        logger.warning("Skipping wallet %s: %s", address, exc)
 
-        async def process_wallet(address: str) -> WalletMetrics | None:
-            async with sem:
-                try:
-                    raw_trades = await client.get_wallet_trades(address)
-                    if not raw_trades:
-                        return None
-                    trades = parse_trades(address, raw_trades)
-                    repo.upsert_trades(trades)
-                    metrics = compute_metrics(trades)
-                    if metrics:
-                        repo.upsert_metrics(metrics)
-                    repo.mark_wallet_scanned(address)
-                    return metrics
-                except Exception as exc:
-                    # Never crash the full scan on a single bad wallet
-                    logger.warning("Skipping wallet %s: %s", address, exc)
-                    return None
+            await asyncio.gather(*[process_wallet(addr) for addr in addresses_to_refresh])
+            logger.info("Refreshed metrics for up to %d wallets", len(addresses_to_refresh))
 
-        tasks = [process_wallet(addr) for addr in addresses]
-        results = await asyncio.gather(*tasks)
-        all_metrics = [r for r in results if r is not None]
-        logger.info("Computed metrics for %d wallets", len(all_metrics))
-
-        # ── Step 3: Hard filters ──────────────────────────────────────────
+        # ── Step 3: Load ALL metrics + apply hard filters ─────────────────────
+        # Always rank the full DB, not just the wallets refreshed this run.
+        all_metrics = repo.get_all_metrics()
         filtered = apply_hard_filters(all_metrics)
         if not filtered:
             logger.warning("No wallets passed hard filters — check MIN_TRADES / MIN_WIN_RATE")
             return []
+        logger.info("Hard filters passed: %d wallets", len(filtered))
 
-        # ── Step 4: Composite ranking ─────────────────────────────────────
+        # ── Step 4: Composite ranking ─────────────────────────────────────────
         rankings = rank_wallets(filtered)
         repo.upsert_rankings(rankings)
 
-        # ── Step 5: Heuristic red flags ───────────────────────────────────
+        # ── Step 5: Heuristic red flags ───────────────────────────────────────
         from analysis.red_flags import get_red_flags
 
         metrics_by_addr = {m.wallet_address: m for m in filtered}
@@ -99,11 +103,29 @@ async def run_scan(
                 flags = get_red_flags(metrics)
                 repo.update_heuristic_flags(ranking.wallet_address, flags)
 
-        # ── Step 6: Claude qualitative review (top N only) ────────────────
+        # ── Step 6: Claude qualitative review (top N only) ────────────────────
         top_n = rankings[:CLAUDE_REVIEW_TOP_N]
         if top_n:
-            logger.info("Sending top %d wallets for Claude review", len(top_n))
-            await _claude_review_pass(top_n, metrics_by_addr)
+            if incremental:
+                # Skip wallets whose Claude review is less than 7 days old
+                cutoff = datetime.utcnow() - timedelta(days=_CLAUDE_REVIEW_TTL_DAYS)
+                db_rankings = repo.get_rankings_for_wallets(
+                    [r.wallet_address for r in top_n]
+                )
+                top_n = [
+                    r for r in top_n
+                    if db_rankings.get(r.wallet_address) is None
+                    or db_rankings[r.wallet_address].reviewed_at is None
+                    or db_rankings[r.wallet_address].reviewed_at < cutoff
+                ]
+                logger.info("Incremental: %d wallets need fresh Claude review", len(top_n))
+
+            if top_n:
+                logger.info("Sending top %d wallets for Claude review", len(top_n))
+                await _claude_review_pass(top_n, metrics_by_addr)
+
+        # ── Step 7: Sync to Turso ─────────────────────────────────────────────
+        sync_to_turso()
 
         logger.info("Scan complete — %d wallets ranked", len(rankings))
         return rankings
@@ -116,7 +138,6 @@ async def _claude_review_pass(
     """Run Claude qualitative review concurrently with a conservative concurrency cap."""
     from analysis.claude_review import review_wallet
 
-    # Claude review: 5 concurrent to stay within rate limits and cost budget
     sem = asyncio.Semaphore(5)
 
     async def review_one(ranking: WalletRanking) -> None:


### PR DESCRIPTION
Implements the full scheduled scan infrastructure from issue #12:

- Restructures -- incremental scan: re-ranks all wallets, 7-day Claude review freshness, empty-DB first-run fallback
- Adds Turso write path via libsql embedded replica
- Documents scheduled scan rules in claude.md and README

⚠️ One manual step: copy the workflow YAML from the issue comment into .github/workflows/scheduled-scan.yml (GitHub App cannot write workflow files).

Closes #12

Generated with [Claude Code](https://claude.ai/code)