### PR TITLE
fix: migrate hosted DB from libSQL/Turso to Neon Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Turso (optional — used by the scheduled GitHub Actions scan)
-# Leave blank for local development (SQLite will be used instead)
-TURSO_DATABASE_URL=libsql://your-database-name.turso.io
-TURSO_AUTH_TOKEN=
+# Neon Postgres (optional — used by the scheduled GitHub Actions scan)
+# Leave blank for local development (SQLite at data/research.db will be used instead)
+# Sign up at neon.tech, create a database, and paste the connection string here.
+DATABASE_URL=postgresql://user:pass@host/db?sslmode=require
 
 # Polymarket API base URLs (configurable for testing or API migration)
 POLYMARKET_DATA_API_BASE=https://data-api.polymarket.com

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ scanner/scanner.py  ← async gather with Semaphore(50) concurrency cap
        └─ claude_review (top 200 only) → skill_signal, edge_hypothesis, notes
               │
               ▼
-         SQLite research.db
+  SQLite (local) or Neon Postgres (hosted)
               │
        ┌──────┴──────────────────────────┐
        ▼                                 ▼
@@ -164,6 +164,7 @@ All settings live in `.env` (see `.env.example`):
 | Variable | Default | Notes |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | *(required)* | Anthropic API key |
+| `DATABASE_URL` | *(optional)* | Neon Postgres connection string; omit to use local SQLite |
 | `POLYMARKET_DATA_API_BASE` | `https://data-api.polymarket.com` | Override for testing |
 | `API_RATE_LIMIT` | `2.0` | Requests/second cap |
 | `MIN_TRADES` | `100` | Hard filter — minimum lifetime trades |
@@ -255,8 +256,8 @@ Filtering this down to the top ~50 wallets with consistent, risk-adjusted skill 
 ## Automated scans
 
 The repository includes a GitHub Actions workflow (`.github/workflows/scheduled-scan.yml`) that
-runs the wallet scanner automatically every **Monday at 06:00 UTC** and writes results to Turso,
-so the leaderboard stays fresh without needing to open Codespaces.
+runs the wallet scanner automatically every **Monday at 06:00 UTC** and writes results to Neon
+Postgres, so the leaderboard stays fresh without needing to open Codespaces.
 
 ### Changing the schedule
 
@@ -288,10 +289,13 @@ Add these under **Settings → Secrets and variables → Actions → New reposit
 | Secret | What it is |
 |---|---|
 | `ANTHROPIC_API_KEY` | Your Anthropic API key (`sk-ant-...`) |
-| `TURSO_DATABASE_URL` | Your Turso database URL (`libsql://yourdb.turso.io`) |
-| `TURSO_AUTH_TOKEN` | Turso auth token for the database |
+| `DATABASE_URL` | Your Neon Postgres connection string (`postgresql://user:pass@host/db?sslmode=require`) |
 
-To create a Turso database: `turso db create wallet-scanner` then `turso db show wallet-scanner`.
+To set up Neon Postgres:
+1. Sign up at [neon.tech](https://neon.tech)
+2. Create a new project and database
+3. Copy the connection string from the dashboard
+4. Add it as `DATABASE_URL` in Vercel environment variables, GitHub Secrets, and your local `.env`
 
 ### Cost expectations
 

--- a/claude.md
+++ b/claude.md
@@ -35,7 +35,7 @@ If hosting on Vercel, the dashboard layer can be a thin FastAPI or Flask app, OR
 - **anthropic** SDK — model `claude-sonnet-4-20250514` for scanner qualitative review, `claude-opus-4-7` only for periodic deep analysis
 - **httpx** (async) for all HTTP — never `requests`
 - **tenacity** for retries with exponential backoff
-- **sqlmodel** for SQLite ORM
+- **sqlmodel** + **sqlalchemy** for ORM; **psycopg[binary]** for Postgres driver
 - **pandas / numpy** for stats
 - **python-dotenv** for config
 - **pytest** + **pytest-asyncio** for tests
@@ -48,7 +48,7 @@ If hosting on Vercel, the dashboard layer can be a thin FastAPI or Flask app, OR
 - **Next.js + Tailwind** if the owner wants a polished mobile-friendly web view, OR plain Jinja2 templates served from FastAPI for a simpler stack
 - Authentication is optional and is the owner's call
 
-Do not add Postgres unless the dataset outgrows SQLite (very unlikely for single-user). Do not add Docker unless the owner asks. Do not add Redis or a job queue — async Python with `asyncio.create_task` is sufficient at this scale.
+Use Postgres (via `DATABASE_URL`) for hosted deployments (Vercel, GitHub Actions). SQLite remains the default for local CLI development. The libSQL/Turso path was abandoned due to driver compatibility issues with SQLAlchemy (`sqlite3.Connection has no create_function attribute`). Do not add Docker unless the owner asks. Do not add Redis or a job queue — async Python with `asyncio.create_task` is sufficient at this scale.
 
 ## Folder structure (canonical)
 
@@ -98,7 +98,9 @@ When adding new functionality, prefer extending an existing module over creating
 - Migrations append-only — add columns, never drop
 - Use transactions for multi-row writes
 - All DB writes go through `repository.py` modules — no inline SQL in business logic
-- If hosted dashboard needs DB access, it reads from the same SQLite file (or Turso/LibSQL if deployed); never duplicates state
+- Local development uses SQLite at `data/research.db` (no env var needed)
+- Hosted deployments use Neon Postgres — set `DATABASE_URL=postgresql://...` in env
+- If hosted dashboard needs DB access, it connects via the same `DATABASE_URL`; never duplicates state
 
 ### Claude API usage
 - Always use the official `anthropic` SDK
@@ -160,9 +162,8 @@ Weekly scans run automatically via `.github/workflows/scheduled-scan.yml` (every
 python main.py scan --incremental
 ```
 
-with `ANTHROPIC_API_KEY`, `TURSO_DATABASE_URL`, and `TURSO_AUTH_TOKEN` injected as GitHub
-secrets. Results are written to a Turso database (libsql embedded replica) and pushed at the
-end of each scan.
+with `ANTHROPIC_API_KEY` and `DATABASE_URL` injected as GitHub secrets. Results are written
+directly to Neon Postgres via the standard SQLAlchemy engine in `data/database.py`.
 
 **Rules that must be preserved in any future scanner changes:**
 
@@ -172,12 +173,7 @@ end of each scan.
    - Still re-ranks all wallets and writes the full leaderboard on every run
    - On first run with an empty DB, falls back to full wallet discovery automatically
 
-2. **The Turso write path must stay intact.** When `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN`
-   are set, the database layer uses a libsql embedded replica (`data/turso_replica.db`) that
-   syncs to Turso at the end of each scan via `sync_to_turso()` in `data/database.py`.
-   Do not remove or bypass this call in `scanner/scanner.py`.
-
-3. **Cost discipline on the scheduled path.** The `--incremental` flag is what keeps the
+2. **Cost discipline on the scheduled path.** The `--incremental` flag is what keeps the
    scheduled run from calling Claude on the full top-200 list every week. If you change the
    Claude review logic, ensure freshness skipping still works.
 

--- a/config.py
+++ b/config.py
@@ -53,12 +53,13 @@ try:
     DATA_DIR.mkdir(exist_ok=True)
 except OSError:
     pass  # read-only filesystem (e.g. Vercel) — DATABASE_URL env var must be set
-DATABASE_URL: str = os.getenv("DATABASE_URL", f"sqlite:///{DATA_DIR}/research.db")
 
-# ── Turso (optional — replaces local SQLite when running in CI/cloud) ─────────
-# Set both to use Turso instead of SQLite. Leave blank for local development.
-TURSO_DATABASE_URL: str = os.getenv("TURSO_DATABASE_URL", "")
-TURSO_AUTH_TOKEN: str = os.getenv("TURSO_AUTH_TOKEN", "")
+_db_url_env: str = os.getenv("DATABASE_URL", "")
+if _db_url_env and (_db_url_env.startswith("postgresql://") or _db_url_env.startswith("postgres://")):
+    DATABASE_URL: str = _db_url_env
+else:
+    # Default: local SQLite for CLI development
+    DATABASE_URL = f"sqlite:///{DATA_DIR}/research.db"
 
 # ── Cache TTLs (seconds) ──────────────────────────────────────────────────────
 # Wallet is considered fresh for 24 h; re-scanned in incremental mode if older

--- a/data/database.py
+++ b/data/database.py
@@ -2,35 +2,21 @@ from __future__ import annotations
 
 from collections.abc import Generator
 
-from sqlmodel import Session, SQLModel, create_engine
+from sqlalchemy import create_engine as _sa_create_engine
+from sqlmodel import Session, SQLModel
 
-from config import DATA_DIR, DATABASE_URL, TURSO_AUTH_TOKEN, TURSO_DATABASE_URL
+from config import DATABASE_URL
 
-_turso_connection = None
+_is_postgres = DATABASE_URL.startswith("postgresql://") or DATABASE_URL.startswith("postgres://")
 
-if TURSO_DATABASE_URL and TURSO_AUTH_TOKEN:
-    try:
-        import libsql_experimental as libsql  # type: ignore[import]
-    except ImportError as exc:
-        raise RuntimeError(
-            "TURSO_DATABASE_URL is set but libsql-experimental is not installed. "
-            "Run: pip install libsql-experimental"
-        ) from exc
-
-    from sqlalchemy.pool import StaticPool
-
-    _local_replica = str(DATA_DIR / "turso_replica.db")
-    _turso_connection = libsql.connect(
-        _local_replica, sync_url=TURSO_DATABASE_URL, auth_token=TURSO_AUTH_TOKEN
-    )
-    _turso_connection.sync()  # Pull latest from Turso before operating
-    _engine = create_engine(
-        "sqlite+pysqlite://",
-        creator=lambda: _turso_connection,
-        poolclass=StaticPool,
+if _is_postgres:
+    _engine = _sa_create_engine(
+        DATABASE_URL,
+        pool_pre_ping=True,
+        pool_recycle=300,
     )
 else:
-    _engine = create_engine(
+    _engine = _sa_create_engine(
         DATABASE_URL,
         connect_args={"check_same_thread": False},
         echo=False,
@@ -51,9 +37,3 @@ def get_engine():
 def get_session() -> Generator[Session, None, None]:
     with Session(_engine) as session:
         yield session
-
-
-def sync_to_turso() -> None:
-    """Push local replica writes to Turso. No-op when using local SQLite."""
-    if _turso_connection is not None:
-        _turso_connection.sync()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ click>=8.1.0
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 ruff>=0.4.0
-libsql-experimental
+psycopg[binary]>=3.1

--- a/scanner/scanner.py
+++ b/scanner/scanner.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime, timedelta
 
 from config import CLAUDE_REVIEW_TOP_N, setup_logging
-from data.database import init_db, sync_to_turso
+from data.database import init_db
 from data.schema import WalletMetrics, WalletRanking
 from scanner import repository as repo
 from scanner.client import PolymarketClient
@@ -123,9 +123,6 @@ async def run_scan(
             if top_n:
                 logger.info("Sending top %d wallets for Claude review", len(top_n))
                 await _claude_review_pass(top_n, metrics_by_addr)
-
-        # ── Step 7: Sync to Turso ─────────────────────────────────────────────
-        sync_to_turso()
 
         logger.info("Scan complete — %d wallets ranked", len(rankings))
         return rankings

--- a/scripts/migrate_local_to_postgres.py
+++ b/scripts/migrate_local_to_postgres.py
@@ -1,0 +1,111 @@
+"""Migrate data from the local SQLite research.db to a Neon Postgres database.
+
+Usage:
+    DATABASE_URL=postgresql://... python scripts/migrate_local_to_postgres.py
+
+The script is idempotent: existing rows in Postgres are skipped via ON CONFLICT DO NOTHING.
+Progress is logged every 1000 rows. Expected runtime for ~10k wallets + 4M trades: 2–5 min.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Allow running from the project root
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import Session, SQLModel
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s — %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 1000
+
+
+def _get_engines():
+    sqlite_path = Path(__file__).parent.parent / "data" / "research.db"
+    if not sqlite_path.exists():
+        raise FileNotFoundError(f"SQLite database not found: {sqlite_path}")
+
+    db_url = os.environ.get("DATABASE_URL", "")
+    if not (db_url.startswith("postgresql://") or db_url.startswith("postgres://")):
+        raise ValueError(
+            "DATABASE_URL must be set to a postgresql:// connection string. "
+            "Example: DATABASE_URL=postgresql://user:pass@host/db?sslmode=require"
+        )
+
+    sqlite_engine = create_engine(
+        f"sqlite:///{sqlite_path}",
+        connect_args={"check_same_thread": False},
+    )
+    pg_engine = create_engine(db_url, pool_pre_ping=True, pool_recycle=300)
+    return sqlite_engine, pg_engine
+
+
+def _migrate_table(
+    sqlite_engine,
+    pg_engine,
+    table_name: str,
+    pk_col: str,
+) -> None:
+    with sqlite_engine.connect() as src:
+        rows = src.execute(text(f"SELECT * FROM {table_name}")).mappings().all()
+
+    if not rows:
+        logger.info("%s: no rows in SQLite, skipping", table_name)
+        return
+
+    logger.info("%s: %d rows to migrate", table_name, len(rows))
+    table = SQLModel.metadata.tables[table_name]
+
+    inserted = 0
+    skipped = 0
+    with pg_engine.begin() as dst:
+        for batch_start in range(0, len(rows), _BATCH_SIZE):
+            batch = [dict(r) for r in rows[batch_start : batch_start + _BATCH_SIZE]]
+            stmt = pg_insert(table).values(batch).on_conflict_do_nothing(index_elements=[pk_col])
+            result = dst.execute(stmt)
+            inserted += result.rowcount
+            skipped += len(batch) - result.rowcount
+            if (batch_start + _BATCH_SIZE) % (_BATCH_SIZE * 10) == 0 or batch_start + _BATCH_SIZE >= len(rows):
+                logger.info(
+                    "%s: %d/%d processed (%d inserted, %d skipped)",
+                    table_name,
+                    min(batch_start + _BATCH_SIZE, len(rows)),
+                    len(rows),
+                    inserted,
+                    skipped,
+                )
+
+    logger.info("%s: done — %d inserted, %d already existed", table_name, inserted, skipped)
+
+
+def main() -> None:
+    import data.schema  # noqa: F401 — registers SQLModel metadata
+
+    sqlite_engine, pg_engine = _get_engines()
+
+    logger.info("Ensuring Postgres schema exists …")
+    SQLModel.metadata.create_all(pg_engine)
+
+    # Tables ordered to satisfy any implicit FK dependencies (metrics/rankings reference wallet)
+    _migrate_table(sqlite_engine, pg_engine, "wallet", "address")
+    _migrate_table(sqlite_engine, pg_engine, "trade", "id")
+    _migrate_table(sqlite_engine, pg_engine, "walletmetrics", "wallet_address")
+    _migrate_table(sqlite_engine, pg_engine, "walletranking", "wallet_address")
+    _migrate_table(sqlite_engine, pg_engine, "watchedwallet", "wallet_address")
+    _migrate_table(sqlite_engine, pg_engine, "alert", "id")
+
+    logger.info("Migration complete.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #16

Replaces the libsql-experimental driver (which broke SQLAlchemy via missing create_function on sqlite3.Connection) with standard psycopg + SQLAlchemy against a Neon Postgres DATABASE_URL.

**Changes:**
- `requirements.txt`: swap libsql-experimental → psycopg[binary]>=3.1
- `config.py`: replace TURSO_* env vars with DATABASE_URL Postgres detection
- `data/database.py`: clean engine setup; Postgres gets pool_pre_ping + pool_recycle=300
- `scanner/scanner.py`: remove sync_to_turso import and call
- `.env.example`: document DATABASE_URL; remove TURSO_* vars
- `scripts/migrate_local_to_postgres.py`: idempotent bulk migration script
- `claude.md` + `README.md`: updated docs

**Note:** The workflow file (.github/workflows/scheduled-scan.yml) needs a manual edit to replace TURSO_* secrets with DATABASE_URL.

Generated with [Claude Code](https://claude.ai/code)