### PR TITLE
feat: add Neon Auth gating with Google/GitHub OAuth and user_watchlist scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
 
+# Neon Auth / Stack Auth — get these from Neon console → Auth → API Keys
+# Leave blank for local development (auth is disabled, app runs open)
+STACK_PROJECT_ID=
+STACK_PUBLISHABLE_CLIENT_KEY=
+STACK_SECRET_SERVER_KEY=
+
 # Neon Postgres (optional — used by the scheduled GitHub Actions scan)
 # Leave blank for local development (SQLite at data/research.db will be used instead)
 # Sign up at neon.tech, create a database, and paste the connection string here.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,19 @@ per-position resolution data including `redeemable` (TRUE = market resolved),
 
 ---
 
+## Accessing the hosted dashboard
+
+The dashboard at [predictionscanner.io](https://predictionscanner.io) requires sign-in via Google or GitHub.
+
+1. Visit `https://predictionscanner.io` — you will be redirected to the sign-in page.
+2. Click **Sign in with Google** or **Sign in with GitHub**.
+3. After OAuth, you land on the leaderboard. Your session is stored in an httpOnly cookie and persists for 30 days.
+4. To sign out, click **Sign out** in the top-right corner.
+
+For access issues contact the owner directly.
+
+---
+
 ## Setup
 
 ### Requirements
@@ -192,6 +205,9 @@ All settings live in `.env` (see `.env.example`):
 |---|---|---|
 | `ANTHROPIC_API_KEY` | *(required)* | Anthropic API key |
 | `DATABASE_URL` | *(optional)* | Neon Postgres connection string; omit to use local SQLite |
+| `STACK_PROJECT_ID` | *(optional)* | Neon Auth project ID — leave blank for local dev (auth disabled) |
+| `STACK_PUBLISHABLE_CLIENT_KEY` | *(optional)* | Neon Auth publishable key (`pk_...`) |
+| `STACK_SECRET_SERVER_KEY` | *(optional)* | Neon Auth secret server key (`sk_...`) |
 | `POLYMARKET_DATA_API_BASE` | `https://data-api.polymarket.com` | Override for testing |
 | `API_RATE_LIMIT` | `2.0` | Requests/second cap |
 | `MIN_TRADES` | `30` | Hard filter — minimum position count |

--- a/api/auth.py
+++ b/api/auth.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import secrets
+from typing import Optional
+
+import httpx
+from fastapi import HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+STACK_PROJECT_ID = os.getenv("STACK_PROJECT_ID", "")
+STACK_PUBLISHABLE_CLIENT_KEY = os.getenv("STACK_PUBLISHABLE_CLIENT_KEY", "")
+STACK_SECRET_SERVER_KEY = os.getenv("STACK_SECRET_SERVER_KEY", "")
+STACK_API_BASE = "https://api.stack-auth.com/api/v1"
+
+SESSION_COOKIE = "ws_session"
+_PKCE_COOKIE = "ws_pkce"
+_STATE_COOKIE = "ws_state"
+COOKIE_MAX_AGE = 30 * 24 * 3600  # 30 days
+
+# When Stack Auth env vars are absent (local dev), auth is disabled and every
+# request is treated as the "local" user so the app still runs without a Neon
+# Auth project configured.
+AUTH_ENABLED = bool(STACK_PROJECT_ID and STACK_PUBLISHABLE_CLIENT_KEY and STACK_SECRET_SERVER_KEY)
+
+_LOCAL_DEV_USER = {"id": "local-dev", "primary_email": "local@dev", "display_name": "Local Dev"}
+
+
+def _base_url(request: Request) -> str:
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("x-forwarded-host", request.url.netloc)
+    return f"{scheme}://{host}"
+
+
+def _callback_url(request: Request) -> str:
+    return f"{_base_url(request)}/api/auth/callback"
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+async def start_oauth(request: Request, provider: str) -> RedirectResponse:
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(32)
+
+    params = {
+        "type": "oauth",
+        "provider_id": provider,
+        "client_id": STACK_PUBLISHABLE_CLIENT_KEY,
+        "redirect_uri": _callback_url(request),
+        "response_type": "code",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    qs = "&".join(f"{k}={v}" for k, v in params.items())
+    auth_url = f"{STACK_API_BASE}/auth/oauth/authorize?{qs}"
+
+    is_secure = _base_url(request).startswith("https://")
+    response = RedirectResponse(auth_url, status_code=302)
+    response.set_cookie(_PKCE_COOKIE, verifier, httponly=True, max_age=600, samesite="lax", secure=is_secure)
+    response.set_cookie(_STATE_COOKIE, state, httponly=True, max_age=600, samesite="lax", secure=is_secure)
+    return response
+
+
+async def handle_callback(request: Request) -> RedirectResponse:
+    code = request.query_params.get("code")
+    state = request.query_params.get("state")
+    error = request.query_params.get("error")
+
+    if error:
+        return RedirectResponse(f"/login?error={error}", status_code=302)
+
+    if not state or state != request.cookies.get(_STATE_COOKIE):
+        return RedirectResponse("/login?error=state_mismatch", status_code=302)
+
+    verifier = request.cookies.get(_PKCE_COOKIE)
+    if not verifier or not code:
+        return RedirectResponse("/login?error=missing_params", status_code=302)
+
+    async with httpx.AsyncClient() as client:
+        try:
+            r = await client.post(
+                f"{STACK_API_BASE}/auth/token",
+                json={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "code_verifier": verifier,
+                    "redirect_uri": _callback_url(request),
+                    "client_id": STACK_PUBLISHABLE_CLIENT_KEY,
+                    "client_secret": STACK_SECRET_SERVER_KEY,
+                },
+                timeout=10.0,
+            )
+        except httpx.RequestError:
+            return RedirectResponse("/login?error=network_error", status_code=302)
+
+    if r.status_code != 200:
+        return RedirectResponse(f"/login?error=token_exchange_failed", status_code=302)
+
+    token_data = r.json()
+    access_token = token_data.get("access_token")
+    if not access_token:
+        return RedirectResponse("/login?error=no_access_token", status_code=302)
+
+    is_secure = _base_url(request).startswith("https://")
+    response = RedirectResponse("/", status_code=302)
+    response.set_cookie(
+        SESSION_COOKIE,
+        access_token,
+        httponly=True,
+        max_age=COOKIE_MAX_AGE,
+        samesite="lax",
+        secure=is_secure,
+    )
+    response.delete_cookie(_PKCE_COOKIE)
+    response.delete_cookie(_STATE_COOKIE)
+    return response
+
+
+async def validate_session(request: Request) -> Optional[dict]:
+    """Return user dict if session is valid, else None.
+
+    When AUTH_ENABLED is False (local dev without Stack Auth keys), always
+    returns the local-dev sentinel user so the app is usable without OAuth.
+    """
+    if not AUTH_ENABLED:
+        return _LOCAL_DEV_USER
+
+    token = request.cookies.get(SESSION_COOKIE)
+    if not token:
+        return None
+
+    async with httpx.AsyncClient() as client:
+        try:
+            r = await client.get(
+                f"{STACK_API_BASE}/users/me",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "x-stack-project-id": STACK_PROJECT_ID,
+                    "x-stack-access-type": "server",
+                    "x-stack-secret-server-key": STACK_SECRET_SERVER_KEY,
+                },
+                timeout=5.0,
+            )
+            if r.status_code == 200:
+                return r.json()
+        except httpx.RequestError:
+            pass
+    return None
+
+
+async def require_auth(request: Request) -> dict:
+    user = await validate_session(request)
+    if not user:
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "Authentication required", "login_url": "/login"},
+        )
+    return user
+
+
+def signout_response(is_secure: bool = True) -> RedirectResponse:
+    response = RedirectResponse("/login", status_code=302)
+    response.delete_cookie(SESSION_COOKIE, secure=is_secure, httponly=True, samesite="lax")
+    return response

--- a/api/index.py
+++ b/api/index.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 import json
 import pathlib
 
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import HTMLResponse
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
 
+from api.auth import AUTH_ENABLED, handle_callback, require_auth, signout_response, start_oauth, validate_session
 from data.database import init_db
 from scanner import repository as repo
 
 app = FastAPI(title="Wallet Scanner", docs_url=None, redoc_url=None)
 
 _DASHBOARD_HTML = pathlib.Path(__file__).parent.parent / "dashboard" / "index.html"
+_LOGIN_HTML = pathlib.Path(__file__).parent.parent / "dashboard" / "login.html"
 
-# Initialize DB tables on cold start (no-op if DB is unavailable)
 try:
     init_db()
 except Exception:
@@ -21,15 +22,69 @@ except Exception:
 
 
 @app.get("/", response_class=HTMLResponse)
-def root() -> str:
+async def root(request: Request):
+    user = await validate_session(request)
+    if not user and AUTH_ENABLED:
+        return RedirectResponse("/login", status_code=302)
     try:
         return _DASHBOARD_HTML.read_text()
     except FileNotFoundError:
-        return "<p>Dashboard not found.</p>"
+        return HTMLResponse("<p>Dashboard not found.</p>", status_code=404)
+
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    user = await validate_session(request)
+    if user and AUTH_ENABLED:
+        return RedirectResponse("/", status_code=302)
+    try:
+        return _LOGIN_HTML.read_text()
+    except FileNotFoundError:
+        return HTMLResponse("<p>Login page not found.</p>", status_code=404)
+
+
+@app.get("/api/auth/login")
+async def auth_login(request: Request, provider: str = "google"):
+    if provider not in ("google", "github"):
+        raise HTTPException(status_code=400, detail="Provider must be 'google' or 'github'")
+    return await start_oauth(request, provider)
+
+
+@app.get("/api/auth/callback")
+async def auth_callback(request: Request):
+    return await handle_callback(request)
+
+
+@app.get("/api/auth/signout")
+async def auth_signout(request: Request):
+    is_secure = request.headers.get("x-forwarded-proto", request.url.scheme) == "https"
+    return signout_response(is_secure=is_secure)
+
+
+@app.get("/api/auth/me")
+async def auth_me(user: dict = Depends(require_auth)) -> dict:
+    return {
+        "id": user.get("id"),
+        "email": user.get("primary_email"),
+        "name": user.get("display_name"),
+    }
+
+
+@app.get("/api/health")
+def health() -> dict:
+    try:
+        total = repo.get_rankings_count()
+        rankings = repo.get_top_rankings(limit=1)
+        last_scan_at = rankings[0].ranked_at.isoformat() if rankings else None
+    except Exception:
+        total = 0
+        last_scan_at = None
+    return {"status": "ok", "ranked_wallet_count": total, "last_scan_at": last_scan_at}
 
 
 @app.get("/api/leaderboard")
-def leaderboard(limit: int = 50) -> dict:
+async def leaderboard(limit: int = 50, user: dict = Depends(require_auth)) -> dict:
+    watched = repo.get_watched_addresses_for_user(user["id"])
     rows = repo.get_top_rankings(limit=min(limit, 200))
     total = repo.get_rankings_count()
     max_ranked_at = max((r.ranked_at for r in rows), default=None)
@@ -63,6 +118,7 @@ def leaderboard(limit: int = 50) -> dict:
             "heuristic_red_flags": heuristic_flags,
             "claude_red_flags": claude_flags,
             "red_flags": heuristic_flags + claude_flags,
+            "is_watched": r.wallet_address in watched,
             "metrics": {
                 "trade_count": metrics.trade_count,
                 "total_pnl": metrics.total_pnl,
@@ -85,8 +141,39 @@ def leaderboard(limit: int = 50) -> dict:
     }
 
 
+@app.get("/api/watchlist")
+async def get_watchlist(user: dict = Depends(require_auth)) -> list[dict]:
+    entries = repo.get_user_watchlist(user["id"])
+    return [
+        {
+            "wallet_address": e.wallet_address,
+            "added_at": e.added_at.isoformat(),
+            "notes": e.notes,
+        }
+        for e in entries
+    ]
+
+
+@app.post("/api/watchlist")
+async def add_watchlist(request: Request, user: dict = Depends(require_auth)) -> dict:
+    body = await request.json()
+    wallet_address = (body.get("wallet_address") or "").strip()
+    if not wallet_address:
+        raise HTTPException(status_code=400, detail="wallet_address is required")
+    added = repo.add_user_watchlist_entry(user["id"], wallet_address)
+    return {"added": added, "wallet_address": wallet_address}
+
+
+@app.delete("/api/watchlist/{address}")
+async def remove_watchlist(address: str, user: dict = Depends(require_auth)) -> dict:
+    removed = repo.remove_user_watchlist_entry(user["id"], address)
+    if not removed:
+        raise HTTPException(status_code=404, detail="Entry not found in watchlist")
+    return {"removed": True, "wallet_address": address}
+
+
 @app.get("/api/alerts")
-def alerts(limit: int = 50) -> list[dict]:
+async def alerts(limit: int = 50, user: dict = Depends(require_auth)) -> list[dict]:
     rows = repo.get_recent_alerts(limit=min(limit, 100))
     return [
         {
@@ -105,7 +192,7 @@ def alerts(limit: int = 50) -> list[dict]:
 
 
 @app.get("/api/wallets/{address}")
-def wallet_detail(address: str) -> dict:
+async def wallet_detail(address: str, user: dict = Depends(require_auth)) -> dict:
     ranking = repo.get_ranking_for_wallet(address)
     metrics = repo.get_metrics_for_wallet(address)
     if ranking is None and metrics is None:

--- a/claude.md
+++ b/claude.md
@@ -165,6 +165,39 @@ When adding new functionality, prefer extending an existing module over creating
 - textual: https://textual.textualize.io/
 - FastAPI: https://fastapi.tiangolo.com/
 
+## Auth (Neon Auth / Stack Auth)
+
+The hosted dashboard requires Google or GitHub OAuth via Neon Auth (built on Stack Auth).
+
+### How it works
+
+1. User visits `/` → FastAPI checks for `ws_session` cookie → if missing/invalid, redirects to `/login`.
+2. `/login` page shows Google and GitHub sign-in buttons (links to `/api/auth/login?provider=google|github`).
+3. `api/auth.py` initiates a PKCE OAuth2 flow against the Stack Auth REST API (`https://api.stack-auth.com/api/v1`).
+4. After OAuth, Stack Auth redirects to `/api/auth/callback` with an authorization code.
+5. FastAPI exchanges the code for an access token and stores it in a 30-day httpOnly cookie (`ws_session`).
+6. Every protected endpoint calls `validate_session()` which hits `GET /api/v1/users/me` on Stack Auth to verify the token.
+
+### Required Vercel env vars
+
+| Variable | Where to find |
+|---|---|
+| `STACK_PROJECT_ID` | Neon console → Auth → API Keys |
+| `STACK_PUBLISHABLE_CLIENT_KEY` | Neon console → Auth → API Keys (starts with `pk_`) |
+| `STACK_SECRET_SERVER_KEY` | Neon console → Auth → API Keys (starts with `sk_`) |
+
+### Local development
+
+Leave all three `STACK_*` vars unset. `AUTH_ENABLED` in `api/auth.py` will be `False`, and every request is treated as a synthetic `local-dev` user. No OAuth flow is triggered.
+
+### Protected routes
+
+All `/api/*` routes except `/api/health` require a valid session. The GitHub Actions scheduler writes directly to Postgres via `DATABASE_URL` — it never touches the API, so it is unaffected by auth.
+
+### User-scoped data
+
+User identity comes from the `id` field in the Stack Auth user object (a UUID, stable per provider account). This is stored as `user_id` in the `user_watchlist` table. User records are managed entirely by Neon Auth (`neon_auth.users_sync` schema); we store only the `id` reference.
+
 ## Scheduled scans
 
 Weekly scans run automatically via `.github/workflows/scheduled-scan.yml` (every Monday at

--- a/config.py
+++ b/config.py
@@ -49,6 +49,14 @@ RANKING_WEIGHTS: dict[str, float] = {
     "portfolio_value": float(os.getenv("WEIGHT_PORTFOLIO_VALUE", "0.10")),
 }
 
+# ── Neon Auth / Stack Auth ────────────────────────────────────────────────────
+# Configure these in Neon console → Auth → API Keys.  When all three are set,
+# the API requires OAuth sign-in via Google or GitHub.  Leave blank for local
+# development — auth is disabled and the app is open with a "local-dev" user.
+STACK_PROJECT_ID: str = os.getenv("STACK_PROJECT_ID", "")
+STACK_PUBLISHABLE_CLIENT_KEY: str = os.getenv("STACK_PUBLISHABLE_CLIENT_KEY", "")
+STACK_SECRET_SERVER_KEY: str = os.getenv("STACK_SECRET_SERVER_KEY", "")
+
 # ── Database ──────────────────────────────────────────────────────────────────
 DATA_DIR: Path = Path(__file__).parent / "data"
 try:

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -40,11 +40,33 @@
 
     header { margin-bottom: 20px; }
 
+    .header-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
     header h1 {
       font-size: 18px;
       font-weight: 600;
       letter-spacing: -0.01em;
     }
+
+    .header-user {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 12px;
+      color: var(--muted);
+      white-space: nowrap;
+    }
+
+    .header-user a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+    .header-user a:hover { text-decoration: underline; }
 
     .header-meta {
       display: flex;
@@ -59,6 +81,19 @@
       content: ' · ';
       margin: 0 4px;
     }
+
+    /* ── Watch button ─────────────────────────────────────────────── */
+
+    .watch-btn {
+      font-size: 12px;
+      background: none;
+      border: none;
+      color: var(--blue);
+      cursor: pointer;
+      padding: 0;
+    }
+    .watch-btn:hover { text-decoration: underline; }
+    .watch-btn.watching { color: var(--muted); }
 
     /* ── Table wrapper ────────────────────────────────────────── */
 
@@ -317,7 +352,10 @@
 <body>
   <div id="app">
     <header>
-      <h1>Wallet Scanner</h1>
+      <div class="header-top">
+        <h1>Wallet Scanner</h1>
+        <div class="header-user" id="user-info"></div>
+      </div>
       <div class="header-meta" id="meta"></div>
     </header>
     <main id="main">
@@ -352,6 +390,31 @@
     let sortKey = 'rank';
     let sortDir = 'asc';
     let openAddr = null;
+
+    // ── Watch toggle ──────────────────────────────────────────────────────────
+
+    async function watchToggle(e, addr) {
+      e.stopPropagation();
+      const w = wallets.find(x => x.address === addr);
+      if (!w) return;
+      const watching = w.is_watched;
+      try {
+        if (watching) {
+          await fetch('/api/watchlist/' + addr, { method: 'DELETE' });
+          w.is_watched = false;
+        } else {
+          await fetch('/api/watchlist', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ wallet_address: addr }),
+          });
+          w.is_watched = true;
+        }
+        render();
+      } catch (err) {
+        showToast('Watchlist update failed');
+      }
+    }
 
     // ── Formatting ────────────────────────────────────────────────────────────
 
@@ -590,6 +653,9 @@
             <div class="detail-actions">
               <a class="action-link" href="https://polymarket.com/profile/${w.address}" target="_blank" rel="noopener noreferrer">View on Polymarket ↗</a>
               <button class="action-link" onclick="copyAddr(event,'${w.address}')">Copy full address</button>
+              <button class="watch-btn${w.is_watched ? ' watching' : ''}" onclick="watchToggle(event,'${w.address}')">
+                ${w.is_watched ? '★ Watching' : '☆ Watch'}
+              </button>
             </div>
           </div>
         </td>
@@ -615,8 +681,23 @@
     // ── Init ──────────────────────────────────────────────────────────────────
 
     async function init() {
+      // Load user info for the header (non-blocking)
+      fetch('/api/auth/me').then(r => {
+        if (r.ok) return r.json();
+      }).then(me => {
+        if (!me) return;
+        const email = me.email || me.name || 'you';
+        document.getElementById('user-info').innerHTML =
+          `<span>Signed in as ${esc(email)}</span>` +
+          `<a href="/api/auth/signout">Sign out</a>`;
+      }).catch(() => {});
+
       try {
         const res = await fetch('/api/leaderboard?limit=50');
+        if (res.status === 401) {
+          window.location.href = '/login';
+          return;
+        }
         if (!res.ok) throw new Error('HTTP ' + res.status);
         const data = await res.json();
 

--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sign In — Wallet Scanner</title>
+  <style>
+    :root {
+      --bg:      #0d1117;
+      --surface: #161b22;
+      --border:  #21262d;
+      --text:    #e6edf3;
+      --muted:   #8b949e;
+      --blue:    #58a6ff;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      font-size: 14px;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 40px 32px;
+      width: 320px;
+      text-align: center;
+    }
+
+    h1 { font-size: 18px; font-weight: 600; margin-bottom: 6px; }
+
+    .sub {
+      color: var(--muted);
+      font-size: 13px;
+      margin-bottom: 28px;
+    }
+
+    .error {
+      color: #f85149;
+      font-size: 12px;
+      margin-bottom: 16px;
+      min-height: 18px;
+    }
+
+    .btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      width: 100%;
+      padding: 10px 16px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+      color: var(--text);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      text-decoration: none;
+      margin-bottom: 10px;
+      transition: background 0.15s, border-color 0.15s;
+    }
+
+    .btn:hover {
+      background: #1c2128;
+      border-color: #30363d;
+    }
+
+    .btn:last-child { margin-bottom: 0; }
+
+    .footer {
+      margin-top: 24px;
+      font-size: 11px;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Wallet Scanner</h1>
+    <p class="sub">Sign in to view the leaderboard</p>
+    <div class="error" id="error-msg"></div>
+
+    <a class="btn" href="/api/auth/login?provider=google">
+      <!-- Google "G" logo -->
+      <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+      </svg>
+      Sign in with Google
+    </a>
+
+    <a class="btn" href="/api/auth/login?provider=github">
+      <!-- GitHub mark -->
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"/>
+      </svg>
+      Sign in with GitHub
+    </a>
+
+    <p class="footer">predictionscanner.io</p>
+  </div>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const err = params.get('error');
+    if (err) {
+      document.getElementById('error-msg').textContent =
+        'Sign-in failed: ' + err.replace(/_/g, ' ');
+    }
+  </script>
+</body>
+</html>

--- a/data/schema.py
+++ b/data/schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+from sqlalchemy import UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -113,3 +114,18 @@ class Alert(SQLModel, table=True):
     price: Optional[float] = Field(default=None)
     details: Optional[str] = Field(default=None)  # JSON blob for extra context
     alerted_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class UserWatchlist(SQLModel, table=True):
+    """Per-user watchlist entries referencing neon_auth.users_sync by user_id."""
+
+    __tablename__ = "user_watchlist"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: str = Field(index=True)  # id from neon_auth.users_sync
+    wallet_address: str = Field(foreign_key="wallet.address", index=True)
+    added_at: datetime = Field(default_factory=datetime.utcnow)
+    notes: Optional[str] = Field(default=None)
+    last_seen_at: datetime = Field(default_factory=datetime.utcnow)
+
+    __table_args__ = (UniqueConstraint("user_id", "wallet_address"),)

--- a/scanner/repository.py
+++ b/scanner/repository.py
@@ -11,6 +11,7 @@ from data.database import get_engine
 from data.schema import (
     Alert,
     Position,
+    UserWatchlist,
     Wallet,
     WalletMetrics,
     WalletRanking,
@@ -227,6 +228,54 @@ def update_watched_positions(address: str, positions_json: str) -> None:
         w.last_position_check = datetime.utcnow()
         s.add(w)
         s.commit()
+
+
+# ── User watchlist ────────────────────────────────────────────────────────────
+
+def get_user_watchlist(user_id: str) -> list[UserWatchlist]:
+    with _session() as s:
+        stmt = select(UserWatchlist).where(UserWatchlist.user_id == user_id)
+        return list(s.exec(stmt).all())
+
+
+def get_watched_addresses_for_user(user_id: str) -> set[str]:
+    with _session() as s:
+        stmt = select(UserWatchlist.wallet_address).where(UserWatchlist.user_id == user_id)
+        return set(s.exec(stmt).all())
+
+
+def add_user_watchlist_entry(user_id: str, wallet_address: str) -> bool:
+    """Return True if added, False if already exists."""
+    with _session() as s:
+        existing = s.exec(
+            select(UserWatchlist).where(
+                UserWatchlist.user_id == user_id,
+                UserWatchlist.wallet_address == wallet_address,
+            )
+        ).first()
+        if existing:
+            return False
+        if not s.get(Wallet, wallet_address):
+            s.add(Wallet(address=wallet_address))
+        s.add(UserWatchlist(user_id=user_id, wallet_address=wallet_address))
+        s.commit()
+        return True
+
+
+def remove_user_watchlist_entry(user_id: str, wallet_address: str) -> bool:
+    """Return True if removed, False if not found."""
+    with _session() as s:
+        entry = s.exec(
+            select(UserWatchlist).where(
+                UserWatchlist.user_id == user_id,
+                UserWatchlist.wallet_address == wallet_address,
+            )
+        ).first()
+        if not entry:
+            return False
+        s.delete(entry)
+        s.commit()
+        return True
 
 
 # ── Alerts ────────────────────────────────────────────────────────────────────

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
       "use": "@vercel/python",
       "config": {
         "includeFiles": [
+          "api/**",
           "data/**",
           "scanner/**",
           "dashboard/**",


### PR DESCRIPTION
Closes #28

Adds Neon Auth (Stack Auth) gating to the hosted dashboard. All `/api/*` routes except `/api/health` now require a valid session cookie obtained via Google or GitHub OAuth. Includes `user_watchlist` table scaffolding and watchlist CRUD endpoints.

Generated with [Claude Code](https://claude.ai/code)