### PR TITLE
feat: deeper strategy analysis pass with structured replicability output

### DIFF
--- a/analysis/strategy_analyzer.py
+++ b/analysis/strategy_analyzer.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+
+import anthropic
+
+from config import (
+    ANTHROPIC_API_KEY,
+    CLAUDE_INPUT_COST_PER_1M,
+    CLAUDE_OUTPUT_COST_PER_1M,
+    CLAUDE_SCANNER_MODEL,
+    STRATEGY_ANALYSIS_MAX_POSITIONS,
+    STRATEGY_ANALYSIS_MAX_TOKENS,
+)
+from data.schema import ClaudeUsageLog, WalletStrategyAnalysis
+from scanner import repository as repo
+
+logger = logging.getLogger(__name__)
+
+PROMPT_VERSION = "v1"
+
+_VALID_STRATEGY_TYPES = frozenset({
+    "arbitrage", "model_driven", "discretionary", "momentum",
+    "contrarian", "vig_capture", "hedging", "information_asymmetry",
+    "hybrid", "unknown",
+})
+
+_client: anthropic.AsyncAnthropic | None = None
+
+
+def _get_client() -> anthropic.AsyncAnthropic:
+    global _client
+    if _client is None:
+        _client = anthropic.AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
+    return _client
+
+
+def _build_strategy_prompt(
+    address: str,
+    metrics_snapshot: dict,
+    top_positions: list,
+    prior_notes: str | None,
+) -> str:
+    total_pnl = metrics_snapshot.get("total_pnl")
+    total_volume = metrics_snapshot.get("total_volume")
+    market_count = metrics_snapshot.get("market_count", 0)
+    realized_count = metrics_snapshot.get("realized_position_count", 0)
+    pct_top3 = metrics_snapshot.get("pct_pnl_from_top_3_positions")
+    composite_score = metrics_snapshot.get("composite_score")
+
+    lines = [
+        "You are analyzing a Polymarket wallet to determine if its trading strategy is replicable.",
+        "Your goal is to produce a paper-tradeable specification — concrete enough that someone",
+        "could read your analysis and start replicating the strategy next week with $10,000.",
+        "",
+        "WALLET CONTEXT:",
+        f"Address: {address}",
+        f"Total P&L: ${total_pnl:,.2f}" if total_pnl is not None else "Total P&L: N/A",
+        f"Total volume: ${total_volume:,.2f}" if total_volume is not None else "Total volume: N/A",
+        f"Distinct markets traded: {market_count}",
+        f"Positions resolved: {realized_count}",
+        f"Top-3 position concentration: {pct_top3:.1%}" if pct_top3 is not None else "Top-3 position concentration: N/A",
+        f"Composite skill score (from earlier analysis): {composite_score:.4f}" if composite_score is not None else "Composite skill score: N/A",
+        "",
+        f"TOP {len(top_positions)} POSITIONS BY P&L IMPACT:",
+        "[title | outcome | avg_price | current_price | size_usd | cash_pnl | hold_days | resolved]",
+    ]
+
+    for i, pos in enumerate(top_positions, start=1):
+        title = (pos.title or pos.condition_id or "?")[:70]
+        outcome = pos.outcome or "?"
+        avg_price = f"{pos.avg_price:.3f}" if pos.avg_price is not None else "?"
+        curr_price = f"{pos.current_price:.3f}" if pos.current_price is not None else "?"
+        size = f"${pos.size:,.0f}" if pos.size is not None else "?"
+        pnl = f"${pos.cash_pnl:,.2f}" if pos.cash_pnl is not None else "?"
+
+        hold_days = "?"
+        if pos.first_seen_at and pos.last_seen_at:
+            delta = pos.last_seen_at - pos.first_seen_at
+            hold_days = f"{delta.days + delta.seconds / 86400:.1f}d"
+
+        resolved = "RESOLVED" if pos.redeemable else "open"
+        lines.append(f"{i}. \"{title}\" | {outcome} | entry={avg_price} | exit={curr_price} | size={size} | pnl={pnl} | hold={hold_days} | {resolved}")
+
+    if prior_notes:
+        lines += [
+            "",
+            "PRIOR ANALYSIS (one-paragraph summary):",
+            prior_notes,
+        ]
+
+    lines += [
+        "",
+        "YOUR TASK:",
+        "",
+        "Analyze this wallet's strategy with the rigor of a quantitative researcher.",
+        "Be skeptical — many 'skilled' wallets just got lucky on a few outcomes. Distinguish between:",
+        "- GENUINE EDGE: systematic exploitation of a market inefficiency",
+        "- INFORMATION ADVANTAGE: knew something the market didn't (often non-replicable)",
+        "- LUCK: a few large outcomes pulled their average up",
+        "- INFRASTRUCTURE EDGE: faster execution, better data feeds, custom models",
+        "",
+        "Output a structured JSON response with EXACTLY these fields (no extra keys, no prose):",
+        "",
+        '{"is_replicable": bool,',
+        ' "replicability_confidence": float 0.0-1.0,',
+        ' "capital_required_min_usd": int or null,',
+        ' "strategy_type": "arbitrage|model_driven|discretionary|momentum|contrarian|vig_capture|hedging|information_asymmetry|hybrid|unknown",',
+        ' "strategy_subtype": "string or null",',
+        ' "entry_signal": "string — observable, specific trigger",',
+        ' "exit_signal": "string — observable, specific trigger",',
+        ' "position_sizing_rule": "string — how big are bets relative to bankroll",',
+        ' "market_selection_criteria": "string — which markets does this apply to",',
+        ' "infrastructure_required": "string — manual, scripted, real-time feed, custom model",',
+        ' "estimated_hit_rate": float 0.0-1.0 or null,',
+        ' "estimated_avg_hold_time_hours": float or null,',
+        ' "estimated_sharpe_proxy": float or null,',
+        ' "failure_modes": ["string", ...],',
+        ' "risk_factors": ["string", ...],',
+        ' "full_thesis": "200-500 word complete reasoning",',
+        ' "paper_trade_recommendation": "Over the next 7 days, take positions matching <criteria>..."}',
+        "",
+        "RULES FOR entry_signal and exit_signal: Be concrete.",
+        "'Sentiment is positive' is WRONG.",
+        "'When NBA spread on Polymarket diverges by >2.5% from DraftKings closing line for a market closing in <90 minutes' is RIGHT.",
+        "",
+        "IMPORTANT: If the data doesn't support confident analysis (fewer than 30 resolved trades,",
+        "or all P&L from 2-3 positions), set is_replicable=false and replicability_confidence low.",
+        "Explain why in full_thesis.",
+    ]
+
+    return "\n".join(lines)
+
+
+def _parse_strategy_response(raw: str, address: str) -> dict | None:
+    text = raw.strip()
+    if text.startswith("```"):
+        parts = text.split("```")
+        text = parts[1] if len(parts) > 1 else text
+        if text.startswith("json"):
+            text = text[4:]
+        text = text.strip()
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("JSON parse failed for strategy response on %s: %s\nRaw: %.300s", address, exc, raw)
+        return None
+
+    required = {
+        "is_replicable", "replicability_confidence", "strategy_type",
+        "entry_signal", "exit_signal", "position_sizing_rule",
+        "market_selection_criteria", "infrastructure_required",
+        "failure_modes", "risk_factors", "full_thesis", "paper_trade_recommendation",
+    }
+    missing = required - set(data.keys())
+    if missing:
+        logger.warning("Strategy response for %s missing fields: %s", address, missing)
+        return None
+
+    if data.get("strategy_type") not in _VALID_STRATEGY_TYPES:
+        logger.warning("Invalid strategy_type '%s' for %s — defaulting to unknown", data.get("strategy_type"), address)
+        data["strategy_type"] = "unknown"
+
+    conf = data.get("replicability_confidence", 0.0)
+    if not isinstance(conf, (int, float)) or not (0.0 <= float(conf) <= 1.0):
+        data["replicability_confidence"] = 0.0
+
+    if not isinstance(data.get("failure_modes"), list):
+        data["failure_modes"] = []
+    if not isinstance(data.get("risk_factors"), list):
+        data["risk_factors"] = []
+
+    return data
+
+
+async def analyze_wallet_strategy(
+    wallet_address: str,
+    top_n_positions: int = STRATEGY_ANALYSIS_MAX_POSITIONS,
+) -> WalletStrategyAnalysis | None:
+    """
+    Run deep Claude strategy analysis for a single wallet.
+    Returns a populated WalletStrategyAnalysis (not yet persisted) or None on failure.
+    """
+    metrics = repo.get_metrics_for_wallet(wallet_address)
+    if metrics is None:
+        logger.warning("No metrics for %s — skipping strategy analysis", wallet_address)
+        return None
+
+    ranking = repo.get_ranking_for_wallet(wallet_address)
+    prior_notes = ranking.claude_notes if ranking else None
+    composite_score = ranking.composite_score if ranking else None
+
+    positions = repo.get_positions_for_wallet(wallet_address)
+    top_positions = sorted(
+        [p for p in positions if p.cash_pnl is not None],
+        key=lambda p: abs(p.cash_pnl),  # type: ignore[arg-type]
+        reverse=True,
+    )[:top_n_positions]
+
+    metrics_snapshot = {
+        "total_pnl": metrics.total_pnl,
+        "total_volume": metrics.total_volume,
+        "market_count": metrics.market_count,
+        "realized_position_count": metrics.realized_position_count,
+        "pct_pnl_from_top_3_positions": metrics.pct_pnl_from_top_3_positions,
+        "composite_score": composite_score,
+        "computed_at": metrics.computed_at.isoformat(),
+    }
+
+    prompt = _build_strategy_prompt(wallet_address, metrics_snapshot, top_positions, prior_notes)
+
+    raw: str | None = None
+    input_tokens = 0
+    output_tokens = 0
+
+    try:
+        client = _get_client()
+        message = await client.messages.create(
+            model=CLAUDE_SCANNER_MODEL,
+            max_tokens=STRATEGY_ANALYSIS_MAX_TOKENS,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = message.content[0].text.strip()
+        input_tokens = message.usage.input_tokens
+        output_tokens = message.usage.output_tokens
+    except anthropic.APIError as exc:
+        logger.warning("Claude API error during strategy analysis for %s: %s", wallet_address, exc)
+        return None
+    finally:
+        if input_tokens or output_tokens:
+            cost = (input_tokens * CLAUDE_INPUT_COST_PER_1M / 1_000_000) + (output_tokens * CLAUDE_OUTPUT_COST_PER_1M / 1_000_000)
+            logger.info(
+                "Strategy analysis for %s: input=%d output=%d cost=$%.4f",
+                wallet_address, input_tokens, output_tokens, cost,
+            )
+            repo.log_claude_usage(ClaudeUsageLog(
+                call_type="strategy_analysis",
+                wallet_address=wallet_address,
+                model_used=CLAUDE_SCANNER_MODEL,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cost_usd=cost,
+            ))
+
+    data = _parse_strategy_response(raw, wallet_address)
+    if data is None:
+        # Retry once
+        logger.info("Retrying strategy analysis parse for %s", wallet_address)
+        data = _parse_strategy_response(raw, wallet_address)
+        if data is None:
+            logger.error("Strategy analysis parse failed twice for %s — skipping", wallet_address)
+            return None
+
+    return WalletStrategyAnalysis(
+        wallet_address=wallet_address,
+        is_replicable=bool(data["is_replicable"]),
+        replicability_confidence=float(data["replicability_confidence"]),
+        capital_required_min_usd=data.get("capital_required_min_usd"),
+        strategy_type=str(data["strategy_type"]),
+        strategy_subtype=data.get("strategy_subtype"),
+        entry_signal=str(data["entry_signal"]),
+        exit_signal=str(data["exit_signal"]),
+        position_sizing_rule=str(data["position_sizing_rule"]),
+        market_selection_criteria=str(data["market_selection_criteria"]),
+        infrastructure_required=str(data["infrastructure_required"]),
+        estimated_hit_rate=data.get("estimated_hit_rate"),
+        estimated_avg_hold_time_hours=data.get("estimated_avg_hold_time_hours"),
+        estimated_sharpe_proxy=data.get("estimated_sharpe_proxy"),
+        failure_modes=json.dumps([str(f) for f in data.get("failure_modes", [])]),
+        risk_factors=json.dumps([str(r) for r in data.get("risk_factors", [])]),
+        prompt_version=PROMPT_VERSION,
+        model_used=CLAUDE_SCANNER_MODEL,
+        generated_at=datetime.utcnow(),
+        wallet_state_snapshot=json.dumps(metrics_snapshot),
+        full_thesis=str(data["full_thesis"]),
+        paper_trade_recommendation=str(data["paper_trade_recommendation"]),
+    )

--- a/api/index.py
+++ b/api/index.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import pathlib
+import uuid
+from datetime import datetime
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from api.auth import AUTH_ENABLED, handle_callback, require_auth, signout_response, start_oauth, validate_session
+from config import STRATEGY_REGEN_DAILY_LIMIT
 from data.database import init_db
 from scanner import repository as repo
 
@@ -78,7 +81,18 @@ def health() -> dict:
     except Exception:
         total = 0
         last_scan_at = None
-    return {"status": "ok", "ranked_wallet_count": total, "last_scan_at": last_scan_at}
+
+    try:
+        claude_usage = repo.get_monthly_claude_usage()
+    except Exception:
+        claude_usage = None
+
+    return {
+        "status": "ok",
+        "ranked_wallet_count": total,
+        "last_scan_at": last_scan_at,
+        "claude_usage_this_month": claude_usage,
+    }
 
 
 @app.get("/api/leaderboard")
@@ -212,6 +226,141 @@ async def alerts(limit: int = 50, user: dict = Depends(require_auth)) -> list[di
         }
         for a in rows
     ]
+
+
+# ── Strategy analysis endpoints ───────────────────────────────────────────────
+
+# In-memory job tracking: job_id -> {status, result, error, created_at}
+_jobs: dict[str, dict] = {}
+
+# Rate limit tracking: user_id -> {date: date, count: int}
+_regen_limits: dict[str, dict] = {}
+
+
+def _check_regen_rate_limit(user_id: str) -> bool:
+    """Return True if under the daily limit, False if exceeded. Increments counter."""
+    today = datetime.utcnow().date()
+    entry = _regen_limits.get(user_id)
+    if entry is None or entry["date"] != today:
+        _regen_limits[user_id] = {"date": today, "count": 0}
+        entry = _regen_limits[user_id]
+    if entry["count"] >= STRATEGY_REGEN_DAILY_LIMIT:
+        return False
+    entry["count"] += 1
+    return True
+
+
+def _serialize_strategy(s) -> dict:
+    return {
+        "id": s.id,
+        "wallet_address": s.wallet_address,
+        "is_replicable": s.is_replicable,
+        "replicability_confidence": s.replicability_confidence,
+        "capital_required_min_usd": s.capital_required_min_usd,
+        "strategy_type": s.strategy_type,
+        "strategy_subtype": s.strategy_subtype,
+        "entry_signal": s.entry_signal,
+        "exit_signal": s.exit_signal,
+        "position_sizing_rule": s.position_sizing_rule,
+        "market_selection_criteria": s.market_selection_criteria,
+        "infrastructure_required": s.infrastructure_required,
+        "estimated_hit_rate": s.estimated_hit_rate,
+        "estimated_avg_hold_time_hours": s.estimated_avg_hold_time_hours,
+        "estimated_sharpe_proxy": s.estimated_sharpe_proxy,
+        "failure_modes": _json_list(s.failure_modes),
+        "risk_factors": _json_list(s.risk_factors),
+        "prompt_version": s.prompt_version,
+        "model_used": s.model_used,
+        "generated_at": s.generated_at.isoformat(),
+        "wallet_state_snapshot": _json_dict(s.wallet_state_snapshot),
+        "full_thesis": s.full_thesis,
+        "paper_trade_recommendation": s.paper_trade_recommendation,
+    }
+
+
+def _json_list(value: str | None) -> list:
+    if not value:
+        return []
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def _json_dict(value: str | None) -> dict:
+    if not value:
+        return {}
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+@app.get("/api/wallet/{address}/strategy")
+async def get_wallet_strategy(address: str, user: dict = Depends(require_auth)) -> dict:
+    """Return the most recent strategy analysis for a wallet, or 404 if none exists."""
+    analysis = repo.get_latest_strategy_analysis(address)
+    if analysis is None:
+        raise HTTPException(status_code=404, detail="No strategy analysis found for this wallet")
+    return _serialize_strategy(analysis)
+
+
+@app.get("/api/wallet/{address}/strategy/history")
+async def get_wallet_strategy_history(address: str, user: dict = Depends(require_auth)) -> list[dict]:
+    """Return all strategy analyses for a wallet, newest first."""
+    analyses = repo.get_strategy_analysis_history(address)
+    return [_serialize_strategy(a) for a in analyses]
+
+
+@app.post("/api/wallet/{address}/strategy/regenerate")
+async def regenerate_wallet_strategy(
+    address: str,
+    background_tasks: BackgroundTasks,
+    user: dict = Depends(require_auth),
+) -> dict:
+    """Trigger fresh strategy analysis for a wallet. Rate-limited to 5/day per user.
+
+    Returns a job_id for polling at GET /api/jobs/{job_id}.
+    """
+    user_id = user.get("id", "unknown")
+    if not _check_regen_rate_limit(user_id):
+        raise HTTPException(
+            status_code=429,
+            detail=f"Daily regeneration limit ({STRATEGY_REGEN_DAILY_LIMIT}) reached. Try again tomorrow.",
+        )
+
+    job_id = str(uuid.uuid4())
+    _jobs[job_id] = {"status": "pending", "result": None, "error": None, "created_at": datetime.utcnow().isoformat()}
+
+    background_tasks.add_task(_run_strategy_job, job_id, address)
+    return {"job_id": job_id, "status": "pending"}
+
+
+async def _run_strategy_job(job_id: str, address: str) -> None:
+    from analysis.strategy_analyzer import analyze_wallet_strategy
+
+    _jobs[job_id]["status"] = "running"
+    try:
+        analysis = await analyze_wallet_strategy(address)
+        if analysis is None:
+            _jobs[job_id]["status"] = "error"
+            _jobs[job_id]["error"] = "Analysis failed or returned no result"
+            return
+        saved = repo.save_strategy_analysis(analysis)
+        _jobs[job_id]["status"] = "complete"
+        _jobs[job_id]["result"] = _serialize_strategy(saved)
+    except Exception as exc:
+        _jobs[job_id]["status"] = "error"
+        _jobs[job_id]["error"] = str(exc)
+
+
+@app.get("/api/jobs/{job_id}")
+async def get_job_status(job_id: str, user: dict = Depends(require_auth)) -> dict:
+    """Poll for async job status. Returns status and result when complete."""
+    job = _jobs.get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return {"job_id": job_id, **job}
 
 
 @app.get("/api/wallets/{address}")

--- a/config.py
+++ b/config.py
@@ -40,6 +40,19 @@ MIN_REALIZED_POSITIONS: int = int(os.getenv("MIN_REALIZED_POSITIONS", "10"))
 # Never call Claude on the full population — only on post-filter top N
 CLAUDE_REVIEW_TOP_N: int = int(os.getenv("CLAUDE_REVIEW_TOP_N", "200"))
 
+# ── Strategy analysis ─────────────────────────────────────────────────────────
+# Deep analysis runs on top N wallets only; Sonnet keeps cost within ~$10/month
+STRATEGY_ANALYSIS_TOP_N: int = int(os.getenv("STRATEGY_ANALYSIS_TOP_N", "10"))
+STRATEGY_ANALYSIS_CACHE_TTL_DAYS: int = int(os.getenv("STRATEGY_ANALYSIS_CACHE_TTL_DAYS", "7"))
+STRATEGY_ANALYSIS_MAX_POSITIONS: int = int(os.getenv("STRATEGY_ANALYSIS_MAX_POSITIONS", "50"))
+STRATEGY_ANALYSIS_MAX_TOKENS: int = 4096
+# Regenerate rate limit per user per day (most expensive endpoint)
+STRATEGY_REGEN_DAILY_LIMIT: int = int(os.getenv("STRATEGY_REGEN_DAILY_LIMIT", "5"))
+
+# ── Claude cost tracking (Sonnet 4 pricing, per 1M tokens) ───────────────────
+CLAUDE_INPUT_COST_PER_1M: float = float(os.getenv("CLAUDE_INPUT_COST_PER_1M", "3.0"))
+CLAUDE_OUTPUT_COST_PER_1M: float = float(os.getenv("CLAUDE_OUTPUT_COST_PER_1M", "15.0"))
+
 # ── Composite ranking weights ─────────────────────────────────────────────────
 RANKING_WEIGHTS: dict[str, float] = {
     "total_pnl": float(os.getenv("WEIGHT_TOTAL_PNL", "0.40")),

--- a/data/schema.py
+++ b/data/schema.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import UniqueConstraint
+from sqlalchemy import Index, UniqueConstraint
 from sqlmodel import Field, SQLModel
 
 
@@ -132,3 +132,64 @@ class UserWatchlist(SQLModel, table=True):
     last_seen_at: datetime = Field(default_factory=datetime.utcnow)
 
     __table_args__ = (UniqueConstraint("user_id", "wallet_address"),)
+
+
+class WalletStrategyAnalysis(SQLModel, table=True):
+    """Deep Claude strategy analysis for a wallet — tracks replicability over time."""
+
+    __tablename__ = "wallet_strategy_analysis"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    wallet_address: str = Field(foreign_key="wallet.address", index=True)
+
+    # Replicability assessment
+    is_replicable: bool
+    replicability_confidence: float
+    capital_required_min_usd: Optional[int] = Field(default=None)
+
+    # Strategy classification
+    strategy_type: str
+    strategy_subtype: Optional[str] = Field(default=None)
+
+    # Replication blueprint
+    entry_signal: str
+    exit_signal: str
+    position_sizing_rule: str
+    market_selection_criteria: str
+    infrastructure_required: str
+
+    # Performance characterization
+    estimated_hit_rate: Optional[float] = Field(default=None)
+    estimated_avg_hold_time_hours: Optional[float] = Field(default=None)
+    estimated_sharpe_proxy: Optional[float] = Field(default=None)
+
+    # Risk assessment (JSON-encoded list[str])
+    failure_modes: str = Field(default="[]")
+    risk_factors: str = Field(default="[]")
+
+    # Meta
+    prompt_version: str
+    model_used: str
+    generated_at: datetime = Field(default_factory=datetime.utcnow)
+    wallet_state_snapshot: str = Field(default="{}")  # JSON-encoded dict
+
+    # Long-form sections
+    full_thesis: str
+    paper_trade_recommendation: str
+
+    __table_args__ = (Index("ix_strategy_wallet_generated", "wallet_address", "generated_at"),)
+
+
+class ClaudeUsageLog(SQLModel, table=True):
+    """Tracks every Claude API call for cost monitoring."""
+
+    __tablename__ = "claude_usage_log"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    call_type: str  # "strategy_analysis" | "scanner_review"
+    wallet_address: Optional[str] = Field(default=None)
+    model_used: str
+    input_tokens: int
+    output_tokens: int
+    cost_usd: float
+    logged_at: datetime = Field(default_factory=datetime.utcnow)

--- a/main.py
+++ b/main.py
@@ -347,6 +347,67 @@ def alerts(interval: int) -> None:
     asyncio.run(run_poll_loop(interval=interval))
 
 
+# ── analyze-strategies ────────────────────────────────────────────────────────
+
+@cli.command("analyze-strategies")
+@click.option("--top", default=10, show_default=True, type=int, help="Analyze top N wallets by composite_score.")
+@click.option("--wallet", default=None, help="Analyze a specific wallet address (overrides --top).")
+@click.option("--force", is_flag=True, default=False, help="Re-analyze even if recent analysis exists.")
+def analyze_strategies(top: int, wallet: str | None, force: bool) -> None:
+    """Deep strategy analysis for top wallets — produces replicability specifications.
+
+    \b
+    Runs the expensive deep Claude pass (top 10 by default, weekly cadence).
+    Results are stored in wallet_strategy_analysis and NOT exposed on the leaderboard yet.
+    Cost: ~$0.50–1.00 per wallet.
+    """
+    from analysis.strategy_analyzer import analyze_wallet_strategy
+    from config import STRATEGY_ANALYSIS_CACHE_TTL_DAYS
+    from scanner import repository as repo
+
+    if wallet:
+        addresses = [wallet.lower()]
+        console.print(f"[bold]Analyzing specific wallet: {addresses[0]}[/bold]")
+    else:
+        rankings = repo.get_top_rankings(limit=top)
+        if not rankings:
+            console.print("[yellow]No rankings found. Run: python main.py scan[/yellow]")
+            return
+        addresses = [r.wallet_address for r in rankings]
+        console.print(f"[bold]Analyzing top {len(addresses)} wallets by composite score…[/bold]")
+
+    analyzed = 0
+    skipped = 0
+    failed = 0
+
+    for address in addresses:
+        if not force:
+            cached = repo.get_fresh_strategy_analysis(address, within_days=STRATEGY_ANALYSIS_CACHE_TTL_DAYS)
+            if cached:
+                console.print(f"  [dim]skip {address[:12]}… (analyzed {cached.generated_at.strftime('%Y-%m-%d')})[/dim]")
+                skipped += 1
+                continue
+
+        console.print(f"  Analyzing [cyan]{address[:12]}…[/cyan]")
+        result = asyncio.run(analyze_wallet_strategy(address))
+        if result is None:
+            console.print(f"  [red]Failed: {address[:12]}…[/red]")
+            failed += 1
+            continue
+
+        repo.save_strategy_analysis(result)
+        replicable = "[green]replicable[/green]" if result.is_replicable else "[yellow]not replicable[/yellow]"
+        console.print(
+            f"  [green]✓[/green] {address[:12]}… — {result.strategy_type} — {replicable} "
+            f"(conf={result.replicability_confidence:.2f})"
+        )
+        analyzed += 1
+
+    console.print(
+        f"\n[bold]Done.[/bold] analyzed={analyzed} skipped={skipped} failed={failed}"
+    )
+
+
 # ── dashboard ─────────────────────────────────────────────────────────────────
 
 @cli.command()

--- a/scanner/repository.py
+++ b/scanner/repository.py
@@ -10,11 +10,13 @@ from sqlmodel import Session, select
 from data.database import get_engine
 from data.schema import (
     Alert,
+    ClaudeUsageLog,
     Position,
     UserWatchlist,
     Wallet,
     WalletMetrics,
     WalletRanking,
+    WalletStrategyAnalysis,
     WatchedWallet,
 )
 
@@ -373,3 +375,76 @@ def get_recent_alerts(limit: int = 100) -> list[Alert]:
     with _session() as s:
         stmt = select(Alert).order_by(Alert.alerted_at.desc()).limit(limit)
         return list(s.exec(stmt).all())
+
+
+# ── Strategy analysis ─────────────────────────────────────────────────────────
+
+def save_strategy_analysis(analysis: WalletStrategyAnalysis) -> WalletStrategyAnalysis:
+    with _session() as s:
+        s.add(analysis)
+        s.commit()
+        s.refresh(analysis)
+        return analysis
+
+
+def get_latest_strategy_analysis(address: str) -> WalletStrategyAnalysis | None:
+    with _session() as s:
+        stmt = (
+            select(WalletStrategyAnalysis)
+            .where(WalletStrategyAnalysis.wallet_address == address)
+            .order_by(WalletStrategyAnalysis.generated_at.desc())
+            .limit(1)
+        )
+        return s.exec(stmt).first()
+
+
+def get_strategy_analysis_history(address: str) -> list[WalletStrategyAnalysis]:
+    with _session() as s:
+        stmt = (
+            select(WalletStrategyAnalysis)
+            .where(WalletStrategyAnalysis.wallet_address == address)
+            .order_by(WalletStrategyAnalysis.generated_at.desc())
+        )
+        return list(s.exec(stmt).all())
+
+
+def get_fresh_strategy_analysis(address: str, within_days: int = 7) -> WalletStrategyAnalysis | None:
+    """Return a recent analysis if one exists within the cache window, else None."""
+    cutoff = datetime.utcnow() - timedelta(days=within_days)
+    with _session() as s:
+        stmt = (
+            select(WalletStrategyAnalysis)
+            .where(
+                WalletStrategyAnalysis.wallet_address == address,
+                WalletStrategyAnalysis.generated_at >= cutoff,
+            )
+            .order_by(WalletStrategyAnalysis.generated_at.desc())
+            .limit(1)
+        )
+        return s.exec(stmt).first()
+
+
+# ── Claude usage log ──────────────────────────────────────────────────────────
+
+def log_claude_usage(log: ClaudeUsageLog) -> None:
+    with _session() as s:
+        s.add(log)
+        s.commit()
+
+
+def get_monthly_claude_usage() -> dict:
+    """Return aggregate Claude usage for the current calendar month."""
+    start_of_month = datetime.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    with _session() as s:
+        rows = s.exec(
+            select(ClaudeUsageLog).where(ClaudeUsageLog.logged_at >= start_of_month)
+        ).all()
+        total_calls = len(rows)
+        total_cost = sum(r.cost_usd for r in rows)
+        strategy_calls = sum(1 for r in rows if r.call_type == "strategy_analysis")
+        return {
+            "total_calls": total_calls,
+            "strategy_analysis_calls": strategy_calls,
+            "total_cost_usd": round(total_cost, 4),
+            "since": start_of_month.isoformat(),
+        }


### PR DESCRIPTION
Closes #34

Adds a second Claude analysis pass targeting top N wallets that produces paper-tradeable strategy specifications stored in `wallet_strategy_analysis`.

**What changed:**
- `data/schema.py`: WalletStrategyAnalysis + ClaudeUsageLog tables
- `config.py`: strategy + cost constants
- `analysis/strategy_analyzer.py`: new module with prompt + parser
- `scanner/repository.py`: CRUD + cost log methods
- `main.py`: analyze-strategies CLI command
- `api/index.py`: GET/POST strategy endpoints + job polling

**Not included:** .github/workflows/strategy-analysis.yml (GitHub App cannot write workflow files — see issue comment for YAML to add manually).

Generated with [Claude Code](https://claude.ai/code)