### PR TITLE
fix: use correct Neon Auth URL paths and add email sign-in

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -39,7 +39,7 @@ async def start_oauth(request: Request, provider: str) -> RedirectResponse:
     async with httpx.AsyncClient() as client:
         try:
             r = await client.post(
-                f"{NEON_AUTH_BASE_URL}/api/auth/sign-in/social",
+                f"{NEON_AUTH_BASE_URL}/sign-in/social",
                 json={"provider": provider, "callbackURL": callback_url},
                 headers={"content-type": "application/json"},
                 timeout=10.0,
@@ -86,7 +86,7 @@ async def validate_session(request: Request) -> Optional[dict]:
     returns the local-dev sentinel user so the app is usable without OAuth.
 
     Validates by forwarding the better-auth.session_token cookie (or an
-    Authorization: Bearer token) to Neon Auth's GET /api/auth/get-session.
+    Authorization: Bearer token) to Neon Auth's GET /get-session.
     """
     if not AUTH_ENABLED:
         return _LOCAL_DEV_USER
@@ -108,7 +108,7 @@ async def validate_session(request: Request) -> Optional[dict]:
     async with httpx.AsyncClient() as client:
         try:
             r = await client.get(
-                f"{NEON_AUTH_BASE_URL}/api/auth/get-session",
+                f"{NEON_AUTH_BASE_URL}/get-session",
                 headers=headers,
                 timeout=5.0,
             )
@@ -136,6 +136,60 @@ async def require_auth(request: Request) -> dict:
     return user
 
 
+async def _email_auth(request: Request, endpoint: str, payload: dict) -> RedirectResponse:
+    """POST to a Better Auth email endpoint and set the session cookie on success."""
+    async with httpx.AsyncClient() as client:
+        try:
+            r = await client.post(
+                f"{NEON_AUTH_BASE_URL}/{endpoint}",
+                json=payload,
+                headers={"content-type": "application/json"},
+                timeout=10.0,
+            )
+        except httpx.RequestError:
+            return RedirectResponse("/login?error=network_error", status_code=302)
+
+    if r.status_code in (200, 201):
+        data = r.json()
+        token = data.get("token")
+        if token:
+            is_secure = _base_url(request).startswith("https://")
+            response = RedirectResponse("/", status_code=302)
+            response.set_cookie(
+                SESSION_COOKIE,
+                token,
+                max_age=COOKIE_MAX_AGE,
+                httponly=True,
+                secure=is_secure,
+                samesite="lax",
+            )
+            return response
+
+    try:
+        error_msg = r.json().get("message", "auth_failed").replace(" ", "_").lower()
+    except Exception:
+        error_msg = "auth_failed"
+    return RedirectResponse(f"/login?error={error_msg}", status_code=302)
+
+
+async def start_email_signin(request: Request, email: str, password: str) -> RedirectResponse:
+    """Sign in with email and password via Better Auth."""
+    return await _email_auth(
+        request,
+        "sign-in/email",
+        {"email": email, "password": password, "rememberMe": True},
+    )
+
+
+async def start_email_signup(request: Request, email: str, password: str, name: str) -> RedirectResponse:
+    """Create an account and sign in via Better Auth."""
+    return await _email_auth(
+        request,
+        "sign-up/email",
+        {"email": email, "password": password, "name": name or email.split("@")[0]},
+    )
+
+
 async def signout_response(request: Request) -> RedirectResponse:
     """Invalidate the Neon Auth session and clear the local session cookie."""
     token = request.cookies.get(SESSION_COOKIE)
@@ -143,7 +197,7 @@ async def signout_response(request: Request) -> RedirectResponse:
         async with httpx.AsyncClient() as client:
             try:
                 await client.post(
-                    f"{NEON_AUTH_BASE_URL}/api/auth/sign-out",
+                    f"{NEON_AUTH_BASE_URL}/sign-out",
                     headers={"cookie": f"{SESSION_COOKIE}={token}"},
                     timeout=5.0,
                 )

--- a/api/index.py
+++ b/api/index.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
-from api.auth import AUTH_ENABLED, handle_callback, require_auth, signout_response, start_oauth, validate_session
+from api.auth import AUTH_ENABLED, handle_callback, require_auth, signout_response, start_email_signin, start_email_signup, start_oauth, validate_session
 from config import STRATEGY_REGEN_DAILY_LIMIT
 from data.database import init_db
 from scanner import repository as repo
@@ -51,6 +51,20 @@ async def auth_login(request: Request, provider: str = "google"):
     if provider not in ("google",):
         raise HTTPException(status_code=400, detail="Provider must be 'google'")
     return await start_oauth(request, provider)
+
+
+@app.post("/api/auth/login/email")
+async def auth_login_email(request: Request):
+    form_data = await request.form()
+    action = str(form_data.get("action") or "signin")
+    email = (str(form_data.get("email") or "")).strip()
+    password = str(form_data.get("password") or "")
+    if not email or not password:
+        return RedirectResponse("/login?error=missing_credentials", status_code=302)
+    if action == "signup":
+        name = (str(form_data.get("name") or "")).strip()
+        return await start_email_signup(request, email, password, name)
+    return await start_email_signin(request, email, password)
 
 
 @app.get("/api/auth/callback")

--- a/claude.md
+++ b/claude.md
@@ -173,11 +173,12 @@ The hosted dashboard uses Google OAuth via **Neon Auth**, which is powered by Be
 ### How it works
 
 1. User visits `/` → FastAPI checks the `better-auth.session_token` cookie → if missing/invalid, redirects to `/login`.
-2. `/login` page shows a "Sign in with Google" button (link to `/api/auth/login?provider=google`).
-3. `api/auth.py` calls `POST {NEON_AUTH_BASE_URL}/api/auth/sign-in/social` to get the Google OAuth redirect URL.
-4. After Google OAuth, Neon Auth handles the callback and redirects the browser to `/api/auth/callback` on our app.
-5. FastAPI validates the session by forwarding the `better-auth.session_token` cookie to `GET {NEON_AUTH_BASE_URL}/api/auth/get-session`.
-6. Every protected endpoint calls `validate_session()` which hits the Neon Auth session endpoint.
+2. `/login` page shows a "Sign in with Google" button (link to `/api/auth/login?provider=google`) and an email/password form (POST to `/api/auth/login/email`).
+3. For Google OAuth: `api/auth.py` calls `POST {NEON_AUTH_BASE_URL}/sign-in/social` to get the provider redirect URL.
+4. For email sign-in: `api/auth.py` calls `POST {NEON_AUTH_BASE_URL}/sign-in/email`; for sign-up: `POST {NEON_AUTH_BASE_URL}/sign-up/email`. On success, the session token is extracted from the response and set as the `better-auth.session_token` cookie.
+5. After Google OAuth, Neon Auth handles the callback and redirects the browser to `/api/auth/callback` on our app.
+6. FastAPI validates the session by forwarding the `better-auth.session_token` cookie to `GET {NEON_AUTH_BASE_URL}/get-session`.
+7. Every protected endpoint calls `validate_session()` which hits the Neon Auth session endpoint.
 
 ### Required Vercel env vars
 

--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -77,6 +77,52 @@
 
     .btn:last-child { margin-bottom: 0; }
 
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 16px 0;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .divider::before, .divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
+
+    .input {
+      width: 100%;
+      padding: 9px 12px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 14px;
+      margin-bottom: 8px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+    .input:focus { border-color: var(--blue); }
+    .input::placeholder { color: var(--muted); }
+
+    .btn-primary {
+      background: var(--blue);
+      color: #0d1117;
+      border-color: var(--blue);
+      font-weight: 600;
+    }
+    .btn-primary:hover { background: #79b8ff; border-color: #79b8ff; }
+
+    .toggle-link {
+      margin-top: 12px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .toggle-link a { color: var(--blue); text-decoration: none; }
+    .toggle-link a:hover { text-decoration: underline; }
+
     .footer {
       margin-top: 24px;
       font-size: 11px;
@@ -101,6 +147,22 @@
       Sign in with Google
     </a>
 
+    <div class="divider">or</div>
+
+    <form id="email-form" method="POST" action="/api/auth/login/email">
+      <input type="hidden" name="action" id="form-action" value="signin" />
+      <div id="name-field" style="display:none">
+        <input type="text" name="name" id="name-input" placeholder="Your name" class="input" autocomplete="name" />
+      </div>
+      <input type="email" name="email" placeholder="Email" required class="input" autocomplete="email" />
+      <input type="password" name="password" id="password-input" placeholder="Password" required class="input" autocomplete="current-password" />
+      <button type="submit" class="btn btn-primary" id="submit-btn">Sign in with Email</button>
+    </form>
+    <p class="toggle-link">
+      <span id="toggle-text">Don't have an account?</span>
+      <a href="#" id="toggle-link" onclick="toggleMode(); return false;">Sign Up</a>
+    </p>
+
     <p class="footer">predictionscanner.io</p>
   </div>
 
@@ -110,6 +172,27 @@
     if (err) {
       document.getElementById('error-msg').textContent =
         'Sign-in failed: ' + err.replace(/_/g, ' ');
+    }
+
+    function toggleMode() {
+      const isSignIn = document.getElementById('form-action').value === 'signin';
+      if (isSignIn) {
+        document.getElementById('form-action').value = 'signup';
+        document.getElementById('name-field').style.display = '';
+        document.getElementById('name-input').required = true;
+        document.getElementById('submit-btn').textContent = 'Sign up with Email';
+        document.getElementById('toggle-text').textContent = 'Already have an account?';
+        document.getElementById('toggle-link').textContent = 'Sign In';
+        document.getElementById('password-input').autocomplete = 'new-password';
+      } else {
+        document.getElementById('form-action').value = 'signin';
+        document.getElementById('name-field').style.display = 'none';
+        document.getElementById('name-input').required = false;
+        document.getElementById('submit-btn').textContent = 'Sign in with Email';
+        document.getElementById('toggle-text').textContent = "Don't have an account?";
+        document.getElementById('toggle-link').textContent = 'Sign Up';
+        document.getElementById('password-input').autocomplete = 'current-password';
+      }
     }
   </script>
 </body>


### PR DESCRIPTION
Fixes the auth integration broken by incorrect URL path construction.

**Root cause:** `api/auth.py` was calling `{NEON_AUTH_BASE_URL}/api/auth/sign-in/social` but Neon Auth's Better Auth REST API does not use the `/api/auth/` prefix.

**Changes:**
- `api/auth.py`: fix all 3 Neon Auth REST call paths, add email sign-in/sign-up helpers
- `api/index.py`: add `POST /api/auth/login/email` endpoint
- `dashboard/login.html`: add email/password form with sign-in/sign-up toggle
- `claude.md`: update auth section with correct URL paths

References PR #33.

Generated with [Claude Code](https://claude.ai/code)