### PR TITLE
refactor: remove auth proxy; frontend calls Neon Auth directly, backend validates JWT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,10 @@
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
 
-# Neon Auth (Better Auth) — get NEON_AUTH_BASE_URL from Neon Console → Auth → Configuration → Auth URL
-# Leave blank for local development (auth is disabled, app runs open)
+# Neon Auth — get from Neon Console → Auth → Configuration → Auth URL
+# Used by: backend for JWKS JWT validation; frontend for direct sign-in/sign-up calls
+# Leave blank for local development (auth is disabled, app runs as local-dev user)
 NEON_AUTH_BASE_URL=
-# Generate with: openssl rand -base64 32
-NEON_AUTH_COOKIE_SECRET=
 
 # Neon Postgres (optional — used by the scheduled GitHub Actions scan)
 # Leave blank for local development (SQLite at data/research.db will be used instead)

--- a/api/auth.py
+++ b/api/auth.py
@@ -3,208 +3,71 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-import httpx
 from fastapi import HTTPException, Request
-from fastapi.responses import RedirectResponse
 
 NEON_AUTH_BASE_URL = os.getenv("NEON_AUTH_BASE_URL", "").rstrip("/")
-NEON_AUTH_COOKIE_SECRET = os.getenv("NEON_AUTH_COOKIE_SECRET", "")
-
-# Better Auth session cookie name
-SESSION_COOKIE = "better-auth.session_token"
-COOKIE_MAX_AGE = 30 * 24 * 3600  # 30 days
-
-# AUTH_ENABLED is True only when NEON_AUTH_BASE_URL is configured.
-# When False (local dev), every request is treated as the "local-dev" user so
-# the app runs without OAuth.
 AUTH_ENABLED = bool(NEON_AUTH_BASE_URL)
 
-_LOCAL_DEV_USER = {"id": "local-dev", "primary_email": "local@dev", "display_name": "Local Dev"}
+_LOCAL_DEV_USER = {"id": "local-dev", "email": "local@dev", "name": "Local Dev"}
+
+_jwks_client: object = None
 
 
-def _base_url(request: Request) -> str:
-    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
-    host = request.headers.get("x-forwarded-host", request.url.netloc)
-    return f"{scheme}://{host}"
+def _get_jwks_client():
+    global _jwks_client
+    if _jwks_client is None and AUTH_ENABLED:
+        from jwt import PyJWKClient  # type: ignore
 
-
-async def start_oauth(request: Request, provider: str) -> RedirectResponse:
-    """Initiate social OAuth via Neon Auth (Better Auth).
-
-    Calls Better Auth's sign-in/social endpoint to obtain the provider redirect
-    URL, then sends the browser to the OAuth provider.
-    """
-    callback_url = f"{_base_url(request)}/api/auth/callback"
-
-    async with httpx.AsyncClient() as client:
-        try:
-            r = await client.post(
-                f"{NEON_AUTH_BASE_URL}/sign-in/social",
-                json={"provider": provider, "callbackURL": callback_url},
-                headers={"content-type": "application/json"},
-                timeout=10.0,
-                follow_redirects=False,
-            )
-        except httpx.RequestError:
-            return RedirectResponse("/login?error=network_error", status_code=302)
-
-    # Better Auth returns {"url": "https://accounts.google.com/..."} on success
-    if r.status_code in (200, 201):
-        data = r.json()
-        redirect_url = data.get("url") or data.get("redirect")
-        if redirect_url:
-            return RedirectResponse(redirect_url, status_code=302)
-    elif r.status_code in (301, 302, 307, 308):
-        location = r.headers.get("location")
-        if location:
-            return RedirectResponse(location, status_code=302)
-
-    return RedirectResponse("/login?error=auth_init_failed", status_code=302)
-
-
-async def handle_callback(request: Request) -> RedirectResponse:
-    """Post-OAuth landing point: validate session and forward to the dashboard.
-
-    After Better Auth completes the OAuth flow on the Neon Auth side, it
-    redirects the browser here.  We validate the session (forwarding the
-    better-auth.session_token cookie to Neon Auth) and go to / on success.
-
-    For this to work, the better-auth.session_token cookie must be readable by
-    this domain.  That requires NEON_AUTH_BASE_URL to share the same origin, or
-    Neon Auth's trusted-origins to be configured to set cross-origin cookies.
-    """
-    user = await validate_session(request)
-    if user:
-        return RedirectResponse("/", status_code=302)
-    return RedirectResponse("/login?error=auth_failed", status_code=302)
+        _jwks_client = PyJWKClient(f"{NEON_AUTH_BASE_URL}/.well-known/jwks.json")
+    return _jwks_client
 
 
 async def validate_session(request: Request) -> Optional[dict]:
-    """Return user dict if session is valid, else None.
+    """Return user dict if JWT is valid, else None.
 
-    When AUTH_ENABLED is False (local dev without Neon Auth configured), always
-    returns the local-dev sentinel user so the app is usable without OAuth.
+    In local dev (AUTH_ENABLED=False), always returns the local-dev sentinel so
+    the app is usable without Neon Auth configured.
 
-    Validates by forwarding the better-auth.session_token cookie (or an
-    Authorization: Bearer token) to Neon Auth's GET /get-session.
+    Validates the JWT from the Authorization: Bearer <token> header by verifying
+    the signature against Neon Auth's JWKS endpoint — no proxying of requests.
     """
     if not AUTH_ENABLED:
         return _LOCAL_DEV_USER
 
-    token = request.cookies.get(SESSION_COOKIE)
-    # Also accept Authorization: Bearer <token> for programmatic API clients
     auth_header = request.headers.get("authorization", "")
-    bearer = auth_header[7:].strip() if auth_header.lower().startswith("bearer ") else ""
-
-    if not token and not bearer:
+    if not auth_header.lower().startswith("bearer "):
         return None
 
-    headers: dict[str, str] = {}
-    if token:
-        headers["cookie"] = f"{SESSION_COOKIE}={token}"
-    if bearer:
-        headers["authorization"] = f"Bearer {bearer}"
+    token = auth_header.split(" ", 1)[1].strip()
+    if not token:
+        return None
 
-    async with httpx.AsyncClient() as client:
-        try:
-            r = await client.get(
-                f"{NEON_AUTH_BASE_URL}/get-session",
-                headers=headers,
-                timeout=5.0,
-            )
-            if r.status_code == 200:
-                data = r.json()
-                user = data.get("user")
-                if user:
-                    return {
-                        "id": user.get("id"),
-                        "primary_email": user.get("email"),
-                        "display_name": user.get("name"),
-                    }
-        except httpx.RequestError:
-            pass
-    return None
+    try:
+        import jwt  # type: ignore
+
+        jwks_client = _get_jwks_client()
+        signing_key = jwks_client.get_signing_key_from_jwt(token).key
+        payload = jwt.decode(
+            token,
+            signing_key,
+            algorithms=["ES256", "RS256"],
+            issuer=NEON_AUTH_BASE_URL,
+        )
+        return {
+            "id": payload.get("sub"),
+            "email": payload.get("email"),
+            "name": payload.get("name"),
+        }
+    except Exception:
+        return None
 
 
 async def require_auth(request: Request) -> dict:
+    """FastAPI dependency: validates JWT and returns user dict, or raises 401."""
     user = await validate_session(request)
     if not user:
         raise HTTPException(
             status_code=401,
-            detail={"error": "Authentication required", "login_url": "/login"},
+            detail={"error": "Authentication required"},
         )
     return user
-
-
-async def _email_auth(request: Request, endpoint: str, payload: dict) -> RedirectResponse:
-    """POST to a Better Auth email endpoint and set the session cookie on success."""
-    async with httpx.AsyncClient() as client:
-        try:
-            r = await client.post(
-                f"{NEON_AUTH_BASE_URL}/{endpoint}",
-                json=payload,
-                headers={"content-type": "application/json"},
-                timeout=10.0,
-            )
-        except httpx.RequestError:
-            return RedirectResponse("/login?error=network_error", status_code=302)
-
-    if r.status_code in (200, 201):
-        data = r.json()
-        token = data.get("token")
-        if token:
-            is_secure = _base_url(request).startswith("https://")
-            response = RedirectResponse("/", status_code=302)
-            response.set_cookie(
-                SESSION_COOKIE,
-                token,
-                max_age=COOKIE_MAX_AGE,
-                httponly=True,
-                secure=is_secure,
-                samesite="lax",
-            )
-            return response
-
-    try:
-        error_msg = r.json().get("message", "auth_failed").replace(" ", "_").lower()
-    except Exception:
-        error_msg = "auth_failed"
-    return RedirectResponse(f"/login?error={error_msg}", status_code=302)
-
-
-async def start_email_signin(request: Request, email: str, password: str) -> RedirectResponse:
-    """Sign in with email and password via Better Auth."""
-    return await _email_auth(
-        request,
-        "sign-in/email",
-        {"email": email, "password": password, "rememberMe": True},
-    )
-
-
-async def start_email_signup(request: Request, email: str, password: str, name: str) -> RedirectResponse:
-    """Create an account and sign in via Better Auth."""
-    return await _email_auth(
-        request,
-        "sign-up/email",
-        {"email": email, "password": password, "name": name or email.split("@")[0]},
-    )
-
-
-async def signout_response(request: Request) -> RedirectResponse:
-    """Invalidate the Neon Auth session and clear the local session cookie."""
-    token = request.cookies.get(SESSION_COOKIE)
-    if token:
-        async with httpx.AsyncClient() as client:
-            try:
-                await client.post(
-                    f"{NEON_AUTH_BASE_URL}/sign-out",
-                    headers={"cookie": f"{SESSION_COOKIE}={token}"},
-                    timeout=5.0,
-                )
-            except httpx.RequestError:
-                pass
-
-    is_secure = _base_url(request).startswith("https://")
-    response = RedirectResponse("/login", status_code=302)
-    response.delete_cookie(SESSION_COOKIE, secure=is_secure, httponly=True, samesite="lax")
-    return response

--- a/api/index.py
+++ b/api/index.py
@@ -6,9 +6,9 @@ import uuid
 from datetime import datetime
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse
 
-from api.auth import AUTH_ENABLED, handle_callback, require_auth, signout_response, start_email_signin, start_email_signup, start_oauth, validate_session
+from api.auth import AUTH_ENABLED, NEON_AUTH_BASE_URL, require_auth
 from config import STRATEGY_REGEN_DAILY_LIMIT
 from data.database import init_db
 from scanner import repository as repo
@@ -25,10 +25,8 @@ except Exception:
 
 
 @app.get("/", response_class=HTMLResponse)
-async def root(request: Request):
-    user = await validate_session(request)
-    if not user and AUTH_ENABLED:
-        return RedirectResponse("/login", status_code=302)
+async def root():
+    # Auth is validated client-side via JWT in localStorage.
     try:
         return _DASHBOARD_HTML.read_text()
     except FileNotFoundError:
@@ -36,54 +34,17 @@ async def root(request: Request):
 
 
 @app.get("/login", response_class=HTMLResponse)
-async def login_page(request: Request):
-    user = await validate_session(request)
-    if user and AUTH_ENABLED:
-        return RedirectResponse("/", status_code=302)
+async def login_page():
     try:
         return _LOGIN_HTML.read_text()
     except FileNotFoundError:
         return HTMLResponse("<p>Login page not found.</p>", status_code=404)
 
 
-@app.get("/api/auth/login")
-async def auth_login(request: Request, provider: str = "google"):
-    if provider not in ("google",):
-        raise HTTPException(status_code=400, detail="Provider must be 'google'")
-    return await start_oauth(request, provider)
-
-
-@app.post("/api/auth/login/email")
-async def auth_login_email(request: Request):
-    form_data = await request.form()
-    action = str(form_data.get("action") or "signin")
-    email = (str(form_data.get("email") or "")).strip()
-    password = str(form_data.get("password") or "")
-    if not email or not password:
-        return RedirectResponse("/login?error=missing_credentials", status_code=302)
-    if action == "signup":
-        name = (str(form_data.get("name") or "")).strip()
-        return await start_email_signup(request, email, password, name)
-    return await start_email_signin(request, email, password)
-
-
-@app.get("/api/auth/callback")
-async def auth_callback(request: Request):
-    return await handle_callback(request)
-
-
-@app.get("/api/auth/signout")
-async def auth_signout(request: Request):
-    return await signout_response(request)
-
-
-@app.get("/api/auth/me")
-async def auth_me(user: dict = Depends(require_auth)) -> dict:
-    return {
-        "id": user.get("id"),
-        "email": user.get("primary_email"),
-        "name": user.get("display_name"),
-    }
+@app.get("/api/config")
+def get_config() -> dict:
+    """Return public frontend configuration (Neon Auth URL for direct SDK calls)."""
+    return {"neon_auth_url": NEON_AUTH_BASE_URL if AUTH_ENABLED else ""}
 
 
 @app.get("/api/health")

--- a/claude.md
+++ b/claude.md
@@ -165,31 +165,33 @@ When adding new functionality, prefer extending an existing module over creating
 - textual: https://textual.textualize.io/
 - FastAPI: https://fastapi.tiangolo.com/
 
-## Auth (Neon Auth — Better Auth backend)
+## Auth (Neon Auth — JWT-validated, decoupled architecture)
 
-The hosted dashboard uses Google OAuth via **Neon Auth**, which is powered by Better Auth.
-**Do NOT use legacy Stack Auth** (`@stackframe/stack`, `api.stack-auth.com`, `STACK_*` vars) — those are not configured for this project and will 404.
+The hosted dashboard uses Neon Auth (powered by Better Auth) for sign-in. The architecture is **decoupled**: the frontend talks to Neon Auth directly; the backend validates JWTs locally via JWKS. There is no auth proxy through our FastAPI backend.
+
+**Do NOT recreate the old proxy pattern** (`/api/auth/*` routes that forwarded requests to Neon Auth). That pattern was removed because it required `python-multipart`, added latency on every request, and coupled availability to Neon Auth being reachable from the server. The previous architectural mistake was: `browser → our FastAPI → Neon Auth`. The correct pattern is: `browser → Neon Auth directly`, then `browser → our FastAPI with JWT`.
 
 ### How it works
 
-1. User visits `/` → FastAPI checks the `better-auth.session_token` cookie → if missing/invalid, redirects to `/login`.
-2. `/login` page shows a "Sign in with Google" button (link to `/api/auth/login?provider=google`) and an email/password form (POST to `/api/auth/login/email`).
-3. For Google OAuth: `api/auth.py` calls `POST {NEON_AUTH_BASE_URL}/sign-in/social` to get the provider redirect URL.
-4. For email sign-in: `api/auth.py` calls `POST {NEON_AUTH_BASE_URL}/sign-in/email`; for sign-up: `POST {NEON_AUTH_BASE_URL}/sign-up/email`. On success, the session token is extracted from the response and set as the `better-auth.session_token` cookie.
-5. After Google OAuth, Neon Auth handles the callback and redirects the browser to `/api/auth/callback` on our app.
-6. FastAPI validates the session by forwarding the `better-auth.session_token` cookie to `GET {NEON_AUTH_BASE_URL}/get-session`.
-7. Every protected endpoint calls `validate_session()` which hits the Neon Auth session endpoint.
+1. User visits `/login` → frontend JavaScript fetches `/api/config` to get `NEON_AUTH_BASE_URL`.
+2. For email sign-in/sign-up: frontend calls `POST {NEON_AUTH_BASE_URL}/sign-in/email` or `/sign-up/email` **directly** → Neon Auth returns `{ token: "eyJ..." }` (a JWT).
+3. For Google OAuth: frontend calls `POST {NEON_AUTH_BASE_URL}/sign-in/social` → gets a Google redirect URL → browser navigates to Google → after OAuth, Neon Auth redirects back to `/login?oauth_callback=1` → frontend calls `GET {NEON_AUTH_BASE_URL}/get-session` with `credentials: 'include'` to retrieve the JWT.
+4. JWT is stored in `localStorage` as `auth_token`.
+5. Every API call from the frontend includes `Authorization: Bearer <jwt>`.
+6. FastAPI's `require_auth` dependency validates the JWT signature via Neon Auth's JWKS endpoint (`{NEON_AUTH_BASE_URL}/.well-known/jwks.json`) using `PyJWT` + `PyJWKClient`. No network call to Neon Auth per request — JWKS keys are cached.
+7. User identity (`sub` claim = user ID) is extracted from the validated JWT payload.
 
 ### Required Vercel env vars
 
 | Variable | Where to find |
 |---|---|
 | `NEON_AUTH_BASE_URL` | Neon Console → Auth → Configuration → Auth URL |
-| `NEON_AUTH_COOKIE_SECRET` | Generate with `openssl rand -base64 32` |
+
+`NEON_AUTH_COOKIE_SECRET` is **not** needed — cookies are managed by Neon Auth's own domain; we use JWTs, not session cookies.
 
 ### Local development
 
-Leave both `NEON_AUTH_*` vars unset. `AUTH_ENABLED` in `api/auth.py` will be `False`, and every request is treated as a synthetic `local-dev` user. No OAuth flow is triggered.
+Leave `NEON_AUTH_BASE_URL` unset. `AUTH_ENABLED` in `api/auth.py` will be `False`. `/api/config` returns `{ "neon_auth_url": "" }`, so the login page immediately redirects to `/`. Every API call is treated as the `local-dev` user — no OAuth flow is triggered.
 
 ### OAuth providers currently enabled
 
@@ -199,18 +201,19 @@ Leave both `NEON_AUTH_*` vars unset. `AUTH_ENABLED` in `api/auth.py` will be `Fa
 
 ### Protected routes
 
-All `/api/*` routes except `/api/health` require a valid session. The GitHub Actions scheduler writes directly to Postgres via `DATABASE_URL` — it never touches the API, so it is unaffected by auth.
+All `/api/*` routes except `/api/health` and `/api/config` require a valid JWT (`Depends(require_auth)`). The GitHub Actions scheduler writes directly to Postgres via `DATABASE_URL` — it never touches the API, so it is unaffected by auth.
 
 ### User-scoped data
 
-User identity comes from the `id` field returned by Neon Auth's get-session endpoint (a string UUID from Better Auth, stable per provider account). This is stored as `user_id` in the `user_watchlist` table. User records are managed by Neon Auth in the `neon_auth.user` schema; we store only the `id` reference.
+User identity comes from the `sub` claim of the validated JWT (a stable UUID from Neon Auth per provider account). This is stored as `user_id` in the `user_watchlist` table.
 
 ### Post-deploy checklist
 
 After deploying to Vercel:
-1. Add `NEON_AUTH_BASE_URL` and `NEON_AUTH_COOKIE_SECRET` to Vercel env vars.
+1. Add `NEON_AUTH_BASE_URL` to Vercel env vars.
 2. Add `predictionscanner.io` to trusted domains: Neon Console → Auth → Configuration → Domains.
-3. Redeploy and test the Google sign-in flow.
+3. Redeploy and test email sign-in and Google sign-in flows.
+4. Verify: `/api/leaderboard` with no Bearer header → 401; with valid JWT → 200.
 
 ## Scheduled scans
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -898,6 +898,30 @@
   <div id="toast"></div>
 
   <script>
+    // ── Auth helpers ──────────────────────────────────────────────────────────
+
+    function getAuthToken() {
+      return localStorage.getItem('auth_token') || '';
+    }
+
+    function getAuthHeaders(extra) {
+      const token = getAuthToken();
+      const auth = token ? { 'Authorization': 'Bearer ' + token } : {};
+      return Object.assign(auth, extra || {});
+    }
+
+    function parseJwt(token) {
+      try {
+        const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        return JSON.parse(window.atob(base64));
+      } catch(e) { return null; }
+    }
+
+    function signOut() {
+      localStorage.removeItem('auth_token');
+      window.location.href = '/login';
+    }
+
     // ── Flag config ───────────────────────────────────────────────────────────
 
     const FLAG_SEV = {
@@ -986,13 +1010,13 @@
       const watching = w.is_watched;
       try {
         if (watching) {
-          await fetch('/api/watchlist/' + addr, { method: 'DELETE' });
+          await fetch('/api/watchlist/' + addr, { method: 'DELETE', headers: getAuthHeaders() });
           w.is_watched = false;
           w.new_activity_count = 0;
         } else {
           await fetch('/api/watchlist', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: getAuthHeaders({ 'Content-Type': 'application/json' }),
             body: JSON.stringify({ wallet_address: addr }),
           });
           w.is_watched = true;
@@ -1140,7 +1164,7 @@
 
         // Mark watched wallet as seen
         if (w && w.is_watched && (w.new_activity_count || 0) > 0) {
-          fetch('/api/watchlist/' + addr + '/seen', { method: 'POST' })
+          fetch('/api/watchlist/' + addr + '/seen', { method: 'POST', headers: getAuthHeaders() })
             .then(() => {
               w.new_activity_count = 0;
               watchlistSummary = computeLocalSummary();
@@ -1172,7 +1196,7 @@
     // ── Strategy fetching ─────────────────────────────────────────────────────
 
     function fetchStrategy(addr, dataMap, loadingSet, errorMap) {
-      fetch('/api/wallet/' + addr + '/strategy')
+      fetch('/api/wallet/' + addr + '/strategy', { headers: getAuthHeaders() })
         .then(res => {
           if (res.status === 404) { dataMap.set(addr, null); return; }
           if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -1203,7 +1227,7 @@
       regenState.set(addr, { loading: true, jobId: null, pollTimerId: null, error: null, rateLimited: false });
       render();
 
-      fetch('/api/wallet/' + addr + '/strategy/regenerate', { method: 'POST' })
+      fetch('/api/wallet/' + addr + '/strategy/regenerate', { method: 'POST', headers: getAuthHeaders() })
         .then(res => {
           if (res.status === 429) {
             regenState.set(addr, { loading: false, jobId: null, pollTimerId: null, error: null, rateLimited: true });
@@ -1227,7 +1251,7 @@
       const state = regenState.get(addr);
       if (!state || !state.jobId) return;
 
-      fetch('/api/jobs/' + state.jobId)
+      fetch('/api/jobs/' + state.jobId, { headers: getAuthHeaders() })
         .then(res => res.json())
         .then(data => {
           if (data.status === 'complete') {
@@ -1259,7 +1283,7 @@
       historyExpanded.add(addr);
       if (!historyData.has(addr) && !historyLoading.has(addr)) {
         historyLoading.add(addr);
-        fetch('/api/wallet/' + addr + '/strategy/history')
+        fetch('/api/wallet/' + addr + '/strategy/history', { headers: getAuthHeaders() })
           .then(res => res.ok ? res.json() : Promise.reject('HTTP ' + res.status))
           .then(data => { historyData.set(addr, data); })
           .catch(e => { historyError.set(addr, String(e)); })
@@ -1810,21 +1834,23 @@
     // ── Init ──────────────────────────────────────────────────────────────────
 
     async function init() {
-      // Load user info for the header and auth state (non-blocking)
-      fetch('/api/auth/me').then(r => {
-        if (r.ok) return r.json();
-      }).then(me => {
-        if (!me) return;
-        currentUser = me;
-        const email = me.email || me.name || 'you';
-        document.getElementById('user-info').innerHTML =
-          `<span>Signed in as ${esc(email)}</span>` +
-          `<a href="/api/auth/signout">Sign out</a>`;
-      }).catch(() => {});
+      // Show user info from JWT (non-blocking — JWT is already in localStorage)
+      const token = getAuthToken();
+      if (token) {
+        const payload = parseJwt(token);
+        if (payload) {
+          currentUser = { id: payload.sub, email: payload.email, name: payload.name };
+          const email = currentUser.email || currentUser.name || 'you';
+          document.getElementById('user-info').innerHTML =
+            `<span>Signed in as ${esc(email)}</span>` +
+            `<a href="#" onclick="signOut(); return false;">Sign out</a>`;
+        }
+      }
 
       try {
-        const res = await fetch('/api/leaderboard?limit=50');
+        const res = await fetch('/api/leaderboard?limit=50', { headers: getAuthHeaders() });
         if (res.status === 401) {
+          localStorage.removeItem('auth_token');
           window.location.href = '/login';
           return;
         }

--- a/dashboard/login.html
+++ b/dashboard/login.html
@@ -76,6 +76,7 @@
     }
 
     .btn:last-child { margin-bottom: 0; }
+    .btn:disabled { opacity: 0.6; cursor: default; }
 
     .divider {
       display: flex;
@@ -136,7 +137,7 @@
     <p class="sub">Sign in to view the leaderboard</p>
     <div class="error" id="error-msg"></div>
 
-    <a class="btn" href="/api/auth/login?provider=google">
+    <button type="button" class="btn" id="google-btn" onclick="signInWithGoogle(event)">
       <!-- Google "G" logo -->
       <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -145,16 +146,16 @@
         <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
       </svg>
       Sign in with Google
-    </a>
+    </button>
 
     <div class="divider">or</div>
 
-    <form id="email-form" method="POST" action="/api/auth/login/email">
+    <form id="email-form">
       <input type="hidden" name="action" id="form-action" value="signin" />
       <div id="name-field" style="display:none">
         <input type="text" name="name" id="name-input" placeholder="Your name" class="input" autocomplete="name" />
       </div>
-      <input type="email" name="email" placeholder="Email" required class="input" autocomplete="email" />
+      <input type="email" name="email" id="email-input" placeholder="Email" required class="input" autocomplete="email" />
       <input type="password" name="password" id="password-input" placeholder="Password" required class="input" autocomplete="current-password" />
       <button type="submit" class="btn btn-primary" id="submit-btn">Sign in with Email</button>
     </form>
@@ -167,11 +168,117 @@
   </div>
 
   <script>
-    const params = new URLSearchParams(location.search);
-    const err = params.get('error');
-    if (err) {
-      document.getElementById('error-msg').textContent =
-        'Sign-in failed: ' + err.replace(/_/g, ' ');
+    // Neon Auth base URL — loaded from /api/config on init
+    let _neonAuthUrl = '';
+
+    function setError(msg) {
+      document.getElementById('error-msg').textContent = msg || '';
+    }
+
+    function parseJwt(token) {
+      try {
+        const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        return JSON.parse(window.atob(base64));
+      } catch(e) { return null; }
+    }
+
+    // Called when returning from Google OAuth flow
+    async function handleOAuthCallback() {
+      // Try to get the session token from Neon Auth cross-origin.
+      // This works if Neon Auth has CORS + SameSite=None cookies configured.
+      try {
+        const res = await fetch(_neonAuthUrl + '/get-session', { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          const token = (data.session && data.session.token) || data.token;
+          if (token) {
+            localStorage.setItem('auth_token', token);
+            window.location.replace('/');
+            return;
+          }
+        }
+      } catch(e) {}
+      setError('OAuth sign-in failed. Please try again.');
+      history.replaceState({}, '', '/login');
+    }
+
+    // Initiate Google OAuth — calls Neon Auth directly, redirects to Google
+    async function signInWithGoogle(e) {
+      e.preventDefault();
+      setError('');
+      const btn = document.getElementById('google-btn');
+      btn.disabled = true;
+      try {
+        const res = await fetch(_neonAuthUrl + '/sign-in/social', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            provider: 'google',
+            callbackURL: window.location.origin + '/login?oauth_callback=1'
+          })
+        });
+        const data = await res.json().catch(() => ({}));
+        const redirectUrl = data.url || data.redirect;
+        if (redirectUrl) {
+          window.location.href = redirectUrl;
+        } else {
+          setError('Failed to initiate Google sign-in');
+          btn.disabled = false;
+        }
+      } catch(err) {
+        setError('Network error. Please try again.');
+        btn.disabled = false;
+      }
+    }
+
+    // Handle email sign-in or sign-up — calls Neon Auth directly
+    async function handleEmailSubmit(e) {
+      e.preventDefault();
+      setError('');
+      const action = document.getElementById('form-action').value;
+      const email = document.getElementById('email-input').value.trim();
+      const password = document.getElementById('password-input').value;
+      const btn = document.getElementById('submit-btn');
+      btn.disabled = true;
+
+      try {
+        let url, body;
+        if (action === 'signup') {
+          const name = (document.getElementById('name-input').value || '').trim()
+            || email.split('@')[0];
+          url = _neonAuthUrl + '/sign-up/email';
+          body = { email, password, name };
+        } else {
+          url = _neonAuthUrl + '/sign-in/email';
+          body = { email, password, rememberMe: true };
+        }
+
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify(body)
+        });
+
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          setError(data.message || 'Authentication failed');
+          return;
+        }
+
+        const token = data.token;
+        if (!token) {
+          setError('No token returned from authentication service');
+          return;
+        }
+        localStorage.setItem('auth_token', token);
+        window.location.replace('/');
+      } catch(err) {
+        setError('Network error. Please try again.');
+      } finally {
+        btn.disabled = false;
+      }
     }
 
     function toggleMode() {
@@ -194,6 +301,43 @@
         document.getElementById('password-input').autocomplete = 'current-password';
       }
     }
+
+    async function init() {
+      // Load Neon Auth URL from backend
+      try {
+        const res = await fetch('/api/config');
+        const data = await res.json();
+        _neonAuthUrl = (data.neon_auth_url || '').replace(/\/$/, '');
+      } catch(e) {}
+
+      if (!_neonAuthUrl) {
+        // Auth not configured (local dev) — go straight to dashboard
+        window.location.replace('/');
+        return;
+      }
+
+      // Handle OAuth callback
+      const params = new URLSearchParams(location.search);
+      if (params.get('oauth_callback')) {
+        await handleOAuthCallback();
+        return;
+      }
+
+      // Redirect to dashboard if already signed in with a non-expired token
+      const token = localStorage.getItem('auth_token');
+      if (token) {
+        const payload = parseJwt(token);
+        if (payload && payload.exp && payload.exp * 1000 > Date.now()) {
+          window.location.replace('/');
+          return;
+        }
+        localStorage.removeItem('auth_token');
+      }
+
+      document.getElementById('email-form').addEventListener('submit', handleEmailSubmit);
+    }
+
+    init();
   </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 ruff>=0.4.0
 psycopg2-binary>=2.9
+PyJWT[crypto]>=2.8.0
+cryptography>=41.0.0


### PR DESCRIPTION
Fixes #39

## Summary

- Removes all `/api/auth/*` proxy routes from FastAPI — the root cause of the `python-multipart` crash
- `api/auth.py` now validates JWTs locally via PyJWKClient (JWKS cached, no per-request proxy call)
- Frontend calls Neon Auth directly for sign-in/sign-up; stores JWT in localStorage; attaches as Bearer token on all API calls
- Adds PyJWT[crypto] and cryptography to requirements.txt; removes NEON_AUTH_COOKIE_SECRET
- Updates CLAUDE.md to document the correct architecture and flag the old proxy pattern

## Test plan

- [ ] `/login` page loads
- [ ] Email sign-up creates a user (verify in neon_auth.user via SQL editor)
- [ ] Email sign-in works, redirects to dashboard
- [ ] Google sign-in redirects to Google, returns to app with session
- [ ] `/api/leaderboard` with no Bearer header → 401
- [ ] `/api/leaderboard` with valid JWT → 200 with data
- [ ] Sign out clears token and redirects to `/login`

Generated with [Claude Code](https://claude.ai/code)