### PR TITLE
fix: replace JWT validation with Neon Auth session lookup

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -1,35 +1,32 @@
 from __future__ import annotations
 
+import hashlib
 import os
+import time
 from typing import Optional
 
+import httpx
 from fastapi import HTTPException, Request
 
 NEON_AUTH_BASE_URL = os.getenv("NEON_AUTH_BASE_URL", "").rstrip("/")
 AUTH_ENABLED = bool(NEON_AUTH_BASE_URL)
 
-_LOCAL_DEV_USER = {"id": "local-dev", "email": "local@dev", "name": "Local Dev"}
+_LOCAL_DEV_USER = {"id": "local-dev", "email": "local@dev", "name": "Local Dev", "role": "user"}
 
-_jwks_client: object = None
-
-
-def _get_jwks_client():
-    global _jwks_client
-    if _jwks_client is None and AUTH_ENABLED:
-        from jwt import PyJWKClient  # type: ignore
-
-        _jwks_client = PyJWKClient(f"{NEON_AUTH_BASE_URL}/.well-known/jwks.json")
-    return _jwks_client
+# In-memory session cache: SHA256(token) -> (user_dict, expiry_timestamp)
+_session_cache: dict[str, tuple[dict, float]] = {}
+_CACHE_TTL = 60.0
 
 
 async def validate_session(request: Request) -> Optional[dict]:
-    """Return user dict if JWT is valid, else None.
+    """Return user dict if session token is valid, else None.
 
     In local dev (AUTH_ENABLED=False), always returns the local-dev sentinel so
     the app is usable without Neon Auth configured.
 
-    Validates the JWT from the Authorization: Bearer <token> header by verifying
-    the signature against Neon Auth's JWKS endpoint — no proxying of requests.
+    Validates the opaque session token from the Authorization: Bearer <token> header
+    by proxying to Neon Auth's /get-session endpoint. Results are cached for 60 s
+    (keyed by SHA256 of the token) to avoid hammering Neon on every request.
     """
     if not AUTH_ENABLED:
         return _LOCAL_DEV_USER
@@ -42,28 +39,44 @@ async def validate_session(request: Request) -> Optional[dict]:
     if not token:
         return None
 
-    try:
-        import jwt  # type: ignore
+    cache_key = hashlib.sha256(token.encode()).hexdigest()
+    now = time.time()
+    cached = _session_cache.get(cache_key)
+    if cached is not None:
+        user_dict, expiry = cached
+        if now < expiry:
+            return user_dict
+        del _session_cache[cache_key]
 
-        jwks_client = _get_jwks_client()
-        signing_key = jwks_client.get_signing_key_from_jwt(token).key
-        payload = jwt.decode(
-            token,
-            signing_key,
-            algorithms=["ES256", "RS256"],
-            issuer=NEON_AUTH_BASE_URL,
-        )
-        return {
-            "id": payload.get("sub"),
-            "email": payload.get("email"),
-            "name": payload.get("name"),
-        }
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                f"{NEON_AUTH_BASE_URL}/get-session",
+                headers={"Cookie": f"__Secure-neon-auth.session_token={token}"},
+            )
     except Exception:
         return None
 
+    if response.status_code != 200:
+        return None
+
+    data = response.json()
+    user_data = data.get("user")
+    if not user_data:
+        return None
+
+    user = {
+        "id": user_data.get("id"),
+        "email": user_data.get("email"),
+        "name": user_data.get("name"),
+        "role": user_data.get("role", "user"),
+    }
+    _session_cache[cache_key] = (user, now + _CACHE_TTL)
+    return user
+
 
 async def require_auth(request: Request) -> dict:
-    """FastAPI dependency: validates JWT and returns user dict, or raises 401."""
+    """FastAPI dependency: validates session token and returns user dict, or raises 401."""
     user = await validate_session(request)
     if not user:
         raise HTTPException(

--- a/claude.md
+++ b/claude.md
@@ -7,7 +7,7 @@ Research tool for analyzing Polymarket wallets. Identifies skilled traders by co
 - Python 3.11+, FastAPI on Vercel serverless
 - React + Vite + TypeScript frontend (in `dashboard/` — built to static assets, served by FastAPI)
 - Postgres via Neon (`DATABASE_URL`), Launch tier for storage headroom
-- Neon Auth (Better Auth) for authentication — JWT-based
+- Neon Auth (Better Auth) for authentication — opaque session tokens
 - Anthropic Claude for qualitative analysis (model: `claude-sonnet-4-5-20250929` or current best Sonnet)
 - Voyage AI for embeddings if/when RAG features are added (`voyage-3`)
 - GitHub Actions for scheduled scans (Mondays 06:00 UTC, 5h timeout, `--incremental`)
@@ -22,7 +22,7 @@ Research tool for analyzing Polymarket wallets. Identifies skilled traders by co
 
 **Backend (FastAPI on Vercel)**
 - API routes under `/api/*` — leaderboard, watchlist CRUD, strategy analysis, regeneration, health
-- Validates JWTs via PyJWT against Neon Auth's JWKS endpoint
+- Validates opaque session tokens by proxying to Neon Auth's `/get-session` endpoint
 - No `/api/auth/*` proxy routes — the frontend talks to Neon Auth directly
 - DB access via SQLModel + psycopg2-binary
 
@@ -60,7 +60,7 @@ Research tool for analyzing Polymarket wallets. Identifies skilled traders by co
 - Frontend handles all auth flows directly via the Neon Auth SDK
 - Backend never proxies auth requests
 - Backend validates the JWT on every protected endpoint via `Depends(get_current_user)`
-- `get_current_user()` is in `api/auth.py`; uses PyJWKClient against `{NEON_AUTH_BASE_URL}/.well-known/jwks.json`
+- `require_auth()` is in `api/auth.py`; sends the bearer token as `__Secure-neon-auth.session_token` cookie to `{NEON_AUTH_BASE_URL}/get-session`, with a 60 s in-memory cache keyed by SHA256(token)
 - `/api/health` is the only public endpoint; everything else is auth-protected
 
 ## Tone and scope


### PR DESCRIPTION
Fixes #45

Neon Auth issues opaque session tokens, not JWTs. The previous PyJWKClient-based validation threw on every request, causing all authenticated endpoints to return 401 and the dashboard leaderboard to spin indefinitely.

Changes:
- Removed all PyJWKClient/JWKS/JWT code
- Validate session by calling Neon Auth's `/get-session` endpoint with the bearer token as a cookie
- Add 60 s in-memory cache (SHA256-keyed) to avoid hammering Neon on every request
- Use httpx.AsyncClient with timeout=5.0
- Keep `require_auth` dependency name and signature unchanged

Generated with [Claude Code](https://claude.ai/code)