### PR TITLE
fix(api): disable audience verification on JWT

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -44,6 +44,7 @@ async def validate_session(request: Request) -> Optional[dict]:
             token,
             signing_key.key,
             algorithms=["EdDSA", "ES256", "RS256", "HS256"],
+            options={"verify_aud": False},
         )
     except Exception as exc:
         logger.warning("%s: %s", type(exc).__name__, exc)


### PR DESCRIPTION
Neon Auth JWTs contain an `aud` claim that doesn't match what PyJWT expects by default, causing InvalidAudienceError and a 401 on every authenticated request.

Passes `options={"verify_aud": False}` to `jwt.decode()` to skip audience verification while keeping signature, expiration, and algorithm checks intact.

Closes #57

Generated with [Claude Code](https://claude.ai/code)