### PR TITLE
fix: redirect to /login on expired JWT or 401

### DIFF
--- a/dashboard/src/components/AuthGuard.tsx
+++ b/dashboard/src/components/AuthGuard.tsx
@@ -1,8 +1,22 @@
 import { Navigate } from 'react-router-dom';
-import { getSession } from '../lib/auth';
+import { getSession, signOut } from '../lib/auth';
+
+function isJwtExpired(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    if (typeof payload.exp !== 'number') return false;
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true; // malformed token treated as expired
+  }
+}
 
 export function AuthGuard({ children }: { children: React.ReactNode }) {
   const session = getSession();
   if (!session) return <Navigate to="/login" replace />;
+  if (isJwtExpired(session.token)) {
+    signOut();
+    return <Navigate to="/login" replace />;
+  }
   return <>{children}</>;
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -9,6 +9,13 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const res = await fetch(path, { ...options, headers });
   if (!res.ok) {
+    if (res.status === 401) {
+      const { signOut } = await import('./auth');
+      signOut();
+      if (window.location.pathname !== '/login') {
+        window.location.href = '/login';
+      }
+    }
     const text = await res.text().catch(() => '');
     const err = new Error(`API ${res.status}: ${text}`) as Error & { status: number };
     err.status = res.status;


### PR DESCRIPTION
Fix expired-JWT handling so users land on /login when their session expires instead of an infinite "Loading..." loop.

- `apiFetch` now calls `signOut()` and redirects to `/login` on 401 responses, using a dynamic import of auth.ts to avoid circular dependencies
- `AuthGuard` now checks JWT expiry client-side; expired tokens are treated as missing sessions and the user is signed out and redirected to /login

Closes #59

Generated with [Claude Code](https://claude.ai/code)