### PR TITLE
feat(strategy): emit structured paper_test_filter

### DIFF
--- a/analysis/strategy_analyzer.py
+++ b/analysis/strategy_analyzer.py
@@ -19,7 +19,7 @@ from scanner import repository as repo
 
 logger = logging.getLogger(__name__)
 
-PROMPT_VERSION = "v1"
+PROMPT_VERSION = "v2"
 
 _VALID_STRATEGY_TYPES = frozenset({
     "arbitrage", "model_driven", "discretionary", "momentum",
@@ -120,7 +120,27 @@ def _build_strategy_prompt(
         ' "failure_modes": ["string", ...],',
         ' "risk_factors": ["string", ...],',
         ' "full_thesis": "200-500 word complete reasoning",',
-        ' "paper_trade_recommendation": "Over the next 7 days, take positions matching <criteria>..."}',
+        ' "paper_trade_recommendation": "Over the next 7 days, take positions matching <criteria>...",',
+        ' "paper_test_filter": {',
+        '   "sports": [<"basketball"|"tennis"|"soccer"|"baseball"|"hockey"|"football"> or null if sport cannot be inferred],',
+        '   "leagues": [<string> e.g. "NBA", "EPL" — empty array means any league],',
+        '   "market_types": [<"binary"|"multi-outcome">],',
+        '   "status": "open" or "any",',
+        '   "hours_until_resolution_min": <number or null>,',
+        '   "hours_until_resolution_max": <number or null>,',
+        '   "min_volume_usd": <number or null>,',
+        '   "min_liquidity_usd": <number or null>,',
+        '   "entry_conditions": [{"type": <"combined_cost_below"|"single_side_discount_below"|"spread_above"|"custom">, "value": <number or null>, "description": <string>}],',
+        '   "exit_conditions": [{"type": <"price_move_pct_in_favor"|"hedge_ratio_suboptimal"|"resolution"|"time_in_position_hours"|"custom">, "value": <number or null>, "description": <string>}],',
+        '   "position_sizing": {"type": <"pct_of_capital"|"fixed_usd">, "value_min": <number>, "value_max": <number>},',
+        '   "duration_days": <number — typically 7>',
+        ' }',
+        '}',
+        "",
+        "RULES FOR paper_test_filter: Base every field on the same reasoning as paper_trade_recommendation.",
+        "If the prose says 'monitor NBA and tennis markets opening within 2-6 hours', then",
+        "sports=[\"basketball\",\"tennis\"], leagues=[\"NBA\"], hours_until_resolution_min=2, hours_until_resolution_max=6.",
+        "If a value cannot be directly inferred from the analysis, set it to null. Do not invent values.",
         "",
         "RULES FOR entry_signal and exit_signal: Be concrete.",
         "'Sentiment is positive' is WRONG.",
@@ -172,6 +192,9 @@ def _parse_strategy_response(raw: str, address: str) -> dict | None:
         data["failure_modes"] = []
     if not isinstance(data.get("risk_factors"), list):
         data["risk_factors"] = []
+
+    if not isinstance(data.get("paper_test_filter"), dict):
+        data["paper_test_filter"] = None
 
     return data
 
@@ -277,4 +300,5 @@ async def analyze_wallet_strategy(
         wallet_state_snapshot=json.dumps(metrics_snapshot),
         full_thesis=str(data["full_thesis"]),
         paper_trade_recommendation=str(data["paper_trade_recommendation"]),
+        paper_test_filter=json.dumps(data["paper_test_filter"]) if data.get("paper_test_filter") is not None else None,
     )

--- a/api/index.py
+++ b/api/index.py
@@ -233,6 +233,7 @@ def _serialize_strategy(s) -> dict:
         "wallet_state_snapshot": _json_dict(s.wallet_state_snapshot),
         "full_thesis": s.full_thesis,
         "paper_trade_recommendation": s.paper_trade_recommendation,
+        "paper_test_filter": _json_dict(s.paper_test_filter) if s.paper_test_filter else None,
     }
 
 

--- a/api/migrations/001_add_paper_test_filter.sql
+++ b/api/migrations/001_add_paper_test_filter.sql
@@ -1,0 +1,6 @@
+-- Migration 001: add paper_test_filter JSONB column to wallet_strategy_analysis
+-- Run once against the Neon Postgres database.
+-- Safe to re-run: the IF NOT EXISTS guard prevents duplicate column errors.
+
+ALTER TABLE wallet_strategy_analysis
+    ADD COLUMN IF NOT EXISTS paper_test_filter JSONB;

--- a/data/schema.py
+++ b/data/schema.py
@@ -177,6 +177,9 @@ class WalletStrategyAnalysis(SQLModel, table=True):
     full_thesis: str
     paper_trade_recommendation: str
 
+    # Structured machine-readable filter derived from paper_trade_recommendation (JSON-encoded)
+    paper_test_filter: Optional[str] = Field(default=None)
+
     __table_args__ = (Index("ix_strategy_wallet_generated", "wallet_address", "generated_at"),)
 
 


### PR DESCRIPTION
Adds machine-readable paper_test_filter JSON alongside prose paper_trade_recommendation.

Closes #61

Generated with [Claude Code](https://claude.ai/code)