### PR TITLE
fix: resolve neverending 401 loop on session expiry

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,5 +1,8 @@
 import { getToken } from './auth';
 
+// Guard against multiple concurrent 401s all racing to redirect.
+let redirectingToLogin = false;
+
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
   const token = getToken();
   const headers: Record<string, string> = {
@@ -9,17 +12,17 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const res = await fetch(path, { ...options, headers });
   if (!res.ok) {
-    if (res.status === 401) {
+    if (res.status === 401 && !redirectingToLogin) {
+      redirectingToLogin = true;
       const { signOut } = await import('./auth');
       signOut();
-      if (window.location.pathname !== '/login') {
-        window.location.href = '/login';
-      }
+      window.location.href = '/login';
     }
     const text = await res.text().catch(() => '');
     const err = new Error(`API ${res.status}: ${text}`) as Error & { status: number };
     err.status = res.status;
     throw err;
   }
+  redirectingToLogin = false;
   return res.json() as Promise<T>;
 }

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -43,6 +43,11 @@ export function isAuthConfigured(): boolean {
 export function signOut(): void {
   localStorage.removeItem('auth_token');
   localStorage.removeItem('auth_user');
+  // Invalidate the server-side session cookie so re-login gets a fresh JWT,
+  // not the stale one tied to the old session.
+  if (NEON_AUTH_URL) {
+    fetch(`${NEON_AUTH_URL}/sign-out`, { method: 'POST', credentials: 'include' }).catch(() => {});
+  }
 }
 
 export async function signInEmail(email: string, password: string): Promise<void> {

--- a/dashboard/src/pages/Leaderboard.tsx
+++ b/dashboard/src/pages/Leaderboard.tsx
@@ -459,14 +459,11 @@ export default function Leaderboard() {
         setDataLoading(false);
       })
       .catch((err) => {
-        if (err && (err as { status?: number }).status === 401) {
-          navigate('/login', { replace: true });
-          return;
-        }
+        if ((err as { status?: number })?.status === 401) return; // apiFetch handles redirect
         setDataError('Failed to load leaderboard. Please refresh.');
         setDataLoading(false);
       });
-  }, [navigate]);
+  }, []);
 
   // ── Strategy fetching ─────────────────────────────────────────────────────
 

--- a/dashboard/src/pages/Watchlist.tsx
+++ b/dashboard/src/pages/Watchlist.tsx
@@ -31,14 +31,11 @@ export default function Watchlist() {
         setLoading(false);
       })
       .catch((err) => {
-        if (err && (err as { status?: number }).status === 401) {
-          navigate('/login', { replace: true });
-          return;
-        }
+        if ((err as { status?: number })?.status === 401) return; // apiFetch handles redirect
         setError('Failed to load watchlist.');
         setLoading(false);
       });
-  }, [navigate]);
+  }, []);
 
   function handleRemove(addr: string) {
     apiFetch(`/api/watchlist/${addr}`, { method: 'DELETE' })


### PR DESCRIPTION
Fixes the infinite 401 loop that prevented users from reaching /login when their session expired.

Three compounding bugs fixed:
1. Double navigation: apiFetch and component catch handlers both tried to redirect on 401, conflicting with each other
2. No concurrent 401 guard: multiple simultaneous API calls raced to redirect, leaving navigation broken
3. Stale session cookie: signOut didn't call the Neon auth server's sign-out endpoint, so re-login got the same expired JWT back

References PR #60

Generated with [Claude Code](https://claude.ai/code)