### PR TITLE
fix: await sign-out before sign-in to prevent ExpiredSignatureError

### DIFF
--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -15,7 +15,7 @@ export async function apiFetch<T>(path: string, options: RequestInit = {}): Prom
     if (res.status === 401 && !redirectingToLogin) {
       redirectingToLogin = true;
       const { signOut } = await import('./auth');
-      signOut();
+      await signOut();
       window.location.href = '/login';
     }
     const text = await res.text().catch(() => '');

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -40,17 +40,20 @@ export function isAuthConfigured(): boolean {
   return Boolean(NEON_AUTH_URL);
 }
 
-export function signOut(): void {
+export async function signOut(): Promise<void> {
   localStorage.removeItem('auth_token');
   localStorage.removeItem('auth_user');
-  // Invalidate the server-side session cookie so re-login gets a fresh JWT,
-  // not the stale one tied to the old session.
+  // Await the server-side sign-out so the session cookie is invalidated before
+  // any subsequent sign-in attempt, preventing ExpiredSignatureError on re-login.
   if (NEON_AUTH_URL) {
-    fetch(`${NEON_AUTH_URL}/sign-out`, { method: 'POST', credentials: 'include' }).catch(() => {});
+    await fetch(`${NEON_AUTH_URL}/sign-out`, { method: 'POST', credentials: 'include' }).catch(() => {});
   }
 }
 
 export async function signInEmail(email: string, password: string): Promise<void> {
+  // Clear any stale server-side session before signing in so the auth server
+  // doesn't see an expired cookie and throw ExpiredSignatureError.
+  await signOut();
   const res = await fetch(`${NEON_AUTH_URL}/sign-in/email`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -68,6 +71,7 @@ export async function signInEmail(email: string, password: string): Promise<void
 }
 
 export async function signUpEmail(email: string, password: string, name: string): Promise<void> {
+  await signOut();
   const res = await fetch(`${NEON_AUTH_URL}/sign-up/email`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
Fixes the `ExpiredSignatureError: Signature has expired` error that prevented re-login after session expiry.

The previous fix (PR #66) fired the Neon `/sign-out` POST as fire-and-forget. The stale session cookie was still active on the server when the user tried to sign in again, causing the auth server to throw `ExpiredSignatureError`.

Changes:
- `signOut()` is now async so the server-side session invalidation can be awaited
- `apiFetch` awaits `signOut()` before navigating to `/login`
- `signInEmail` and `signUpEmail` pre-emptively await `signOut()` at their start, guaranteeing any stale session cookie is invalidated before the new sign-in request

References PR #66

Generated with [Claude Code](https://claude.ai/code)