### PR TITLE
fix: break ExpiredSignatureError loop with credential-less sign-in retry

### DIFF
--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -51,21 +51,50 @@ export async function signOut(): Promise<void> {
 }
 
 export async function signInEmail(email: string, password: string): Promise<void> {
-  // Clear any stale server-side session before signing in so the auth server
-  // doesn't see an expired cookie and throw ExpiredSignatureError.
   await signOut();
-  const res = await fetch(`${NEON_AUTH_URL}/sign-in/email`, {
+
+  let res = await fetch(`${NEON_AUTH_URL}/sign-in/email`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
     body: JSON.stringify({ email, password, rememberMe: true }),
   });
+
+  // If the Neon server rejects our request because the expired session cookie
+  // wasn't cleared by /sign-out (the server validates the cookie even on sign-out),
+  // retry without credentials so the stale cookie isn't sent.
+  let sentCredentials = true;
+  if (!res.ok) {
+    const errData = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (/expired|ExpiredSignature/i.test(String(errData['message'] || ''))) {
+      sentCredentials = false;
+      res = await fetch(`${NEON_AUTH_URL}/sign-in/email`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'omit',
+        body: JSON.stringify({ email, password, rememberMe: true }),
+      });
+    }
+  }
+
   const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
   if (!res.ok) throw new Error(String(data['message'] || 'Authentication failed'));
   const user = data['user'] as Record<string, unknown> | undefined;
   if (user) persistUser(user);
-  const sessionRes = await fetch(`${NEON_AUTH_URL}/get-session`, { credentials: 'include' });
-  const jwt = sessionRes.headers.get('set-auth-jwt');
+
+  // Prefer the JWT from the sign-in response itself — avoids a /get-session
+  // round-trip that could also trip over a stale cookie.
+  const session = data['session'] as Record<string, unknown> | undefined;
+  const jwtFromBody = (
+    (session?.['access_token'] ?? data['access_token'] ?? data['token']) as string | undefined
+  );
+  let jwt: string | null = res.headers.get('set-auth-jwt') ?? jwtFromBody ?? null;
+
+  if (!jwt && sentCredentials) {
+    const sessionRes = await fetch(`${NEON_AUTH_URL}/get-session`, { credentials: 'include' });
+    jwt = sessionRes.headers.get('set-auth-jwt');
+  }
+
   if (!jwt) throw new Error('No JWT returned from authentication service');
   localStorage.setItem('auth_token', jwt);
 }
@@ -82,8 +111,19 @@ export async function signUpEmail(email: string, password: string, name: string)
   if (!res.ok) throw new Error(String(data['message'] || 'Sign-up failed'));
   const user = data['user'] as Record<string, unknown> | undefined;
   if (user) persistUser(user);
-  const sessionRes = await fetch(`${NEON_AUTH_URL}/get-session`, { credentials: 'include' });
-  const jwt = sessionRes.headers.get('set-auth-jwt');
+
+  // Prefer the JWT from the sign-up response itself.
+  const session = data['session'] as Record<string, unknown> | undefined;
+  const jwtFromBody = (
+    (session?.['access_token'] ?? data['access_token'] ?? data['token']) as string | undefined
+  );
+  let jwt: string | null = res.headers.get('set-auth-jwt') ?? jwtFromBody ?? null;
+
+  if (!jwt) {
+    const sessionRes = await fetch(`${NEON_AUTH_URL}/get-session`, { credentials: 'include' });
+    jwt = sessionRes.headers.get('set-auth-jwt');
+  }
+
   if (!jwt) throw new Error('No JWT returned from authentication service');
   localStorage.setItem('auth_token', jwt);
 }

--- a/dashboard/src/pages/Leaderboard.tsx
+++ b/dashboard/src/pages/Leaderboard.tsx
@@ -938,9 +938,9 @@ export default function Leaderboard() {
 
   // ── Sign out ──────────────────────────────────────────────────────────────
 
-  function handleSignOut(e: React.MouseEvent) {
+  async function handleSignOut(e: React.MouseEvent) {
     e.preventDefault();
-    signOut();
+    await signOut();
     navigate('/login', { replace: true });
   }
 


### PR DESCRIPTION
Fixes the persistent `ExpiredSignatureError: Signature has expired` that blocks re-login after session expiry.

**Root cause:** When the Neon auth server validates the session cookie on every request (including `/sign-out`), an expired cookie can never be cleared server-side — `/sign-out` itself throws and we swallow the error. The stale cookie then blocks `/sign-in/email` before credentials are even checked.

**Changes:**
- `signInEmail`: detect `ExpiredSignatureError` from the first attempt and retry with `credentials: 'omit'` so the stale cookie is not sent
- Both `signInEmail` and `signUpEmail`: read JWT from the sign-in response directly (`set-auth-jwt` header or body fields) to avoid the `/get-session` round-trip that could also fail on the stale cookie
- `Leaderboard.handleSignOut`: `await signOut()` instead of fire-and-forget

References PR #66

Generated with [Claude Code](https://claude.ai/code)